### PR TITLE
feat: add cidr service

### DIFF
--- a/cmd/dnstoys/handlers.go
+++ b/cmd/dnstoys/handlers.go
@@ -23,7 +23,7 @@ type handlers struct {
 	help     []dns.RR
 }
 
-var reClean = regexp.MustCompile("[^a-zA-Z0-9/\\-\\.]")
+var reClean = regexp.MustCompile("[^a-zA-Z0-9/\\-\\.:]")
 
 // register registers a Service for a given query suffix on the DNS server.
 // A Service responds to a DNS query via Query().

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/knadh/dns.toys/internal/geo"
+	"github.com/knadh/dns.toys/internal/services/cidr"
 	"github.com/knadh/dns.toys/internal/services/fx"
 	"github.com/knadh/dns.toys/internal/services/num2words"
 	"github.com/knadh/dns.toys/internal/services/timezones"
@@ -224,6 +225,14 @@ func main() {
 		h.register("words", n, mux)
 
 		help = append(help, []string{"convert numbers to words.", "dig 123456.words @%s"})
+	}
+
+	// CIDR.
+	if ko.Bool("cidr.enabled") {
+		n := cidr.New()
+		h.register("cidr", n, mux)
+
+		help = append(help, []string{"convert cidr to ip range.", "dig 10.100.0.0/24 @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -48,3 +48,6 @@ enabled = true
 
 [num2words]
 enabled = true
+
+[cidr]
+enabled = true

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,6 +94,15 @@
 	</section>
 
 	<section class="box">
+		<h2>Usable CIDR Range</h1>
+		<code class="block">
+			<p>dig 10.0.0.0/24.cidr @dns.toys</p>
+			<p>dig 2001:db8::/108.cidr @dns.toys</p>
+		</code>
+		<p>Parse CIDR notation to find out first and last usable IP address in the subnet.</p>
+	</section>
+
+	<section class="box">
 		<h2>Help</h1>
 		<code class="block">
 			<p>dig help @dns.toys</p>

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/knadh/koanf v1.4.1
 	github.com/miekg/dns v1.1.49
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/time v0.0.0-20220411224347-583f2d630306
 )
 
 require (
@@ -17,7 +18,6 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/internal/services/cidr/cidr.go
+++ b/internal/services/cidr/cidr.go
@@ -1,0 +1,85 @@
+// package cidr returns usable IP range for a given IP Address prefix.
+package cidr
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+)
+
+type CIDR struct{}
+
+// New returns a new instance of CIDR.
+func New() *CIDR {
+	return &CIDR{}
+}
+
+// Query parses a given query string and returns the answer.
+// For the cidr package, the query is an IP Address Prefix (CIDR notation).
+func (c *CIDR) Query(q string) ([]string, error) {
+	ipAddr, network, err := net.ParseCIDR(q)
+	if err != nil {
+		return nil, errors.New("invalid cidr notation.")
+	}
+	prefixLen, bits := network.Mask.Size()
+
+	switch {
+	// Handle ipv4.
+	case ipAddr.To4() != nil:
+		// Binary "AND" operation between the IP address and the subnet mask.
+		for i := range network.IP.To4() {
+			network.IP[i] &= network.Mask[i]
+		}
+		// Ignore the first IP as it's the base IP which is unusable.
+		// If /31 assume a point-to-point // link and return the lower address.
+		if prefixLen < 31 {
+			network.IP[3]++
+		}
+		first := network.IP.To4().String()
+
+		// Binary "OR" operation on the IP with the bitwise binary inverse of the subnet mask to the first IP address.
+		for i := range network.IP.To4() {
+			network.IP[i] |= ^network.Mask[i]
+		}
+		// Ignore the last IP as it's the broadcast IP which is unusable.
+		// If /31 then assume a point-to-point link and return upper address.
+		if prefixLen < 31 {
+			network.IP[3]--
+		}
+		last := network.IP.To4().String()
+
+		// Get the size of subnet.
+		size := 1 << (uint64(bits) - uint64(prefixLen))
+
+		r := fmt.Sprintf("%s 1 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
+		return []string{r}, nil
+
+	// Handle ipv6.
+	case ipAddr.To16() != nil:
+		for i := range network.IP.To16() {
+			network.IP[i] &= network.Mask[i]
+		}
+		first := network.IP.To16().String()
+
+		for i := range network.IP.To16() {
+			network.IP[i] |= ^network.Mask[i]
+		}
+		last := network.IP.To16().String()
+
+		// uint32 won't suffice for IPv6 prefixes lesser than /65.
+		size := big.NewInt(1)
+		size = size.Lsh(size, uint(bits-prefixLen))
+
+		r := fmt.Sprintf("%s 1 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
+		return []string{r}, nil
+
+	default:
+		return nil, errors.New("unable to parse ip.")
+	}
+}
+
+// Dump produces a gob dump of the cached data.
+func (c *CIDR) Dump() ([]byte, error) {
+	return nil, nil
+}


### PR DESCRIPTION
The format of the answer is: `"first" "last" "count"`.

```
dig +noall +answer +additional 10.0.0.0/24.cidr @127.0.0.1 -p 5354
10.0.0.0/24.		1	IN	TXT	"10.0.0.1" "10.0.0.254" "256"

dig +noall +answer +additional 2001:db8::/120.cidr @127.0.0.1 -p 5354
2001:db8::/120.		1	IN	TXT	"2001:db8::" "2001:db8::ff" "256"
```

**NOTE**: I'd to edit the `regex` to incorporate `:` which is used by IPv6 notation.

Closes https://github.com/knadh/dns.toys/issues/1