### PR TITLE
Added pi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dnstoys.bin
+config.toml

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ dig 100USD-INR.fx @dns.toys
 dig ip @dns.toys
 
 dig 987654321.words @dns.toys
+
+dig pi @dns.toys
 ```
 
 ## Running locally

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -32,6 +32,9 @@ var (
 	buildString = "unknown"
 )
 
+// Not all platforms have syscall.SIGUNUSED so use Golang's default definition here
+const SIGUNUSED = syscall.Signal(0x1f)
+
 func initConfig() {
 	// Register --help handler.
 	f := flag.NewFlagSet("config", flag.ContinueOnError)
@@ -68,7 +71,7 @@ func saveSnapshot(h *handlers) {
 		syscall.SIGHUP,
 		syscall.SIGQUIT,
 		syscall.SIGINT,
-		syscall.SIGUNUSED, // SIGUNUSED, can be used to avoid shutting down the app.
+		SIGUNUSED, // SIGUNUSED, can be used to avoid shutting down the app.
 	)
 
 	// On receiving an OS signal, iterate through services and
@@ -99,7 +102,7 @@ func saveSnapshot(h *handlers) {
 				}
 			}
 
-			if i != syscall.SIGUNUSED {
+			if i != SIGUNUSED {
 				os.Exit(0)
 			}
 		}

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -238,6 +238,13 @@ func main() {
 		help = append(help, []string{"convert cidr to ip range.", "dig 10.100.0.0/24.cidr @%s"})
 	}
 
+	// PI.
+	if ko.Bool("pi.enabled") {
+		mux.HandleFunc("pi.", h.handlePi)
+
+		help = append(help, []string{"return pi as TXT or A or AAAA record.", "dig ip @%s"})
+	}
+
 	// Prepare the static help response for the `help` query.
 	for _, l := range help {
 		r, err := dns.NewRR(fmt.Sprintf("help. 1 TXT \"%s\" \"%s\"", l[0], fmt.Sprintf(l[1], h.domain)))

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -51,3 +51,6 @@ enabled = true
 
 [cidr]
 enabled = true
+
+[pi]
+enabled = true

--- a/docs/index.html
+++ b/docs/index.html
@@ -142,6 +142,16 @@
 		</div>
 	</section>
 
+	<section class="box">
+		<h2>PI</h2>
+		<code class="block">
+			<p>dig pi @dns.toys</p>
+			<p>dig pi -t txt @dns.toys</p>
+			<p>dig pi -t aaaa @dns.toys</p>
+		</code>
+		<p>Return &pi; in TXT, A, and AAAA records.</p>
+	</section>
+
 	<section>
 		<h1>Why?</h1>
 		Why not? For fun. I spend a lot of time on the terminal and doing quick unit


### PR DESCRIPTION
Querying pi returns π in different records:

```
> dig pi -p 5354 @localhost +short -t TXT
"3.141592653589793115997963468544185161590576"

> dig pi -p 5354 @localhost +short -t A
3.141.59.26

> dig pi -p 5354 @localhost +short -t AAAA
3141:5926:5358:9793:2384:6264:3383:2795
````