### PR TITLE
feature: add base service

### DIFF
--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/knadh/dns.toys/internal/geo"
+	"github.com/knadh/dns.toys/internal/services/base"
 	"github.com/knadh/dns.toys/internal/services/cidr"
 	"github.com/knadh/dns.toys/internal/services/fx"
 	"github.com/knadh/dns.toys/internal/services/num2words"
@@ -233,6 +234,14 @@ func main() {
 		h.register("cidr", n, mux)
 
 		help = append(help, []string{"convert cidr to ip range.", "dig 10.100.0.0/24.cidr @%s"})
+	}
+
+	// Base
+	if ko.Bool("base.enabled") {
+		n := base.New()
+		h.register("base", n, mux)
+
+		help = append(help, []string{"convert numbers from one base to another", "dig 100dec-hex.base @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -51,3 +51,6 @@ enabled = true
 
 [cidr]
 enabled = true
+
+[base]
+enabled = true

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,15 @@
 	</section>
 
 	<section class="box">
+		<h2>Number from one base to another</h2>
+		<code class="block">
+			<p>dig 100dec-hex.base @dns.toys</p>
+			<p>dig 755oct-bin.base @dns.toys</p>
+		</code>
+		<p>Converts a number from one base to another. Supported bases are hex, dec, oct and bin.</p>
+	</section>
+
+	<section class="box">
 		<h2>Help</h2>
 		<code class="block">
 			<p>dig help @dns.toys</p>

--- a/internal/services/base/base.go
+++ b/internal/services/base/base.go
@@ -1,0 +1,61 @@
+package base
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Base struct{}
+
+// New returns a new instance of Base.
+func New() *Base {
+	return &Base{}
+}
+
+var numQueryFormat = regexp.MustCompile("([0-9A-F\\.]+)([A-Z]{3})\\-([A-Z]{3})")
+
+var baseStrToNum = map[string]int{
+	"HEX": 16,
+	"DEC": 10,
+	"OCT": 8,
+	"BIN": 2,
+}
+
+// Query converts a number from one base to another base format
+func (n *Base) Query(q string) ([]string, error) {
+
+	q = strings.ToUpper(q)
+
+	reg := numQueryFormat.FindStringSubmatch(q)
+	if len(reg) != 4 {
+		return nil, errors.New("invalid base query.")
+	}
+
+	fromBase, ok := baseStrToNum[reg[2]]
+	if !ok {
+		return nil, errors.New("invalid number system; must be one of hex, dec, oct, bin.")
+	}
+
+	toBase, ok := baseStrToNum[reg[3]]
+	if !ok {
+		return nil, errors.New("invalid number system; must be one of hex, dec, oct, bin.")
+	}
+
+	num, err := strconv.ParseInt(reg[1], fromBase, 64)
+	if err != nil {
+		return nil, errors.New("invalid number.")
+	}
+
+	res := strings.ToUpper(strconv.FormatInt(num, toBase))
+
+	r := fmt.Sprintf("%s 1 TXT \"%s %s = %s %s\"", q, reg[1], reg[2], res, reg[3])
+	return []string{r}, nil
+}
+
+// Dump is not implemented in this package.
+func (n *Base) Dump() ([]byte, error) {
+	return nil, nil
+}


### PR DESCRIPTION
The base service converts a number
from one base format to another. The
supported formats are hex, dec, oct
and bin