### PR TITLE
feature: add base service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ dig ip @dns.toys
 dig 987654321.words @dns.toys
 
 dig pi @dns.toys
+
+dig 100dec-hex.base @dns.toys
 ```
 
 ## Running locally

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/knadh/dns.toys/internal/geo"
+	"github.com/knadh/dns.toys/internal/services/base"
 	"github.com/knadh/dns.toys/internal/services/cidr"
 	"github.com/knadh/dns.toys/internal/services/fx"
 	"github.com/knadh/dns.toys/internal/services/num2words"
@@ -243,6 +244,14 @@ func main() {
 		mux.HandleFunc("pi.", h.handlePi)
 
 		help = append(help, []string{"return pi as TXT or A or AAAA record.", "dig ip @%s"})
+	}
+
+	// Base
+	if ko.Bool("base.enabled") {
+		n := base.New()
+		h.register("base", n, mux)
+
+		help = append(help, []string{"convert numbers from one base to another", "dig 100dec-hex.base @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -54,3 +54,6 @@ enabled = true
 
 [pi]
 enabled = true
+
+[base]
+enabled = true

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,15 @@
 	</section>
 
 	<section class="box">
+		<h2>Number from one base to another</h2>
+		<code class="block">
+			<p>dig 100dec-hex.base @dns.toys</p>
+			<p>dig 755oct-bin.base @dns.toys</p>
+		</code>
+		<p>Converts a number from one base to another. Supported bases are hex, dec, oct and bin.</p>
+	</section>
+
+	<section class="box">
 		<h2>Help</h2>
 		<code class="block">
 			<p>dig help @dns.toys</p>

--- a/internal/services/base/base.go
+++ b/internal/services/base/base.go
@@ -1,0 +1,61 @@
+package base
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Base struct{}
+
+// New returns a new instance of Base.
+func New() *Base {
+	return &Base{}
+}
+
+var numQueryFormat = regexp.MustCompile("([0-9A-F\\.]+)([A-Z]{3})\\-([A-Z]{3})")
+
+var baseStrToNum = map[string]int{
+	"HEX": 16,
+	"DEC": 10,
+	"OCT": 8,
+	"BIN": 2,
+}
+
+// Query converts a number from one base to another base format
+func (n *Base) Query(q string) ([]string, error) {
+
+	q = strings.ToUpper(q)
+
+	reg := numQueryFormat.FindStringSubmatch(q)
+	if len(reg) != 4 {
+		return nil, errors.New("invalid base query.")
+	}
+
+	fromBase, ok := baseStrToNum[reg[2]]
+	if !ok {
+		return nil, errors.New("invalid number system; must be one of hex, dec, oct, bin.")
+	}
+
+	toBase, ok := baseStrToNum[reg[3]]
+	if !ok {
+		return nil, errors.New("invalid number system; must be one of hex, dec, oct, bin.")
+	}
+
+	num, err := strconv.ParseInt(reg[1], fromBase, 64)
+	if err != nil {
+		return nil, errors.New("invalid number.")
+	}
+
+	res := strings.ToUpper(strconv.FormatInt(num, toBase))
+
+	r := fmt.Sprintf("%s 1 TXT \"%s %s = %s %s\"", q, reg[1], reg[2], res, reg[3])
+	return []string{r}, nil
+}
+
+// Dump is not implemented in this package.
+func (n *Base) Dump() ([]byte, error) {
+	return nil, nil
+}

--- a/internal/services/base/base.go
+++ b/internal/services/base/base.go
@@ -15,19 +15,19 @@ func New() *Base {
 	return &Base{}
 }
 
-var numQueryFormat = regexp.MustCompile("([0-9A-F\\.]+)([A-Z]{3})\\-([A-Z]{3})")
+var numQueryFormat = regexp.MustCompile("([0-9a-f\\.]+)([a-z]{3})\\-([a-z]{3})")
 
 var baseStrToNum = map[string]int{
-	"HEX": 16,
-	"DEC": 10,
-	"OCT": 8,
-	"BIN": 2,
+	"hex": 16,
+	"dec": 10,
+	"oct": 8,
+	"bin": 2,
 }
 
 // Query converts a number from one base to another base format
 func (n *Base) Query(q string) ([]string, error) {
 
-	q = strings.ToUpper(q)
+	q = strings.ToLower(q)
 
 	reg := numQueryFormat.FindStringSubmatch(q)
 	if len(reg) != 4 {
@@ -49,7 +49,7 @@ func (n *Base) Query(q string) ([]string, error) {
 		return nil, errors.New("invalid number.")
 	}
 
-	res := strings.ToUpper(strconv.FormatInt(num, toBase))
+	res := strconv.FormatInt(num, toBase)
 
 	r := fmt.Sprintf("%s 1 TXT \"%s %s = %s %s\"", q, reg[1], reg[2], res, reg[3])
 	return []string{r}, nil


### PR DESCRIPTION
The base service converts a number
from one base format to another. The
supported formats are hex, dec, oct
and bin