### PR TITLE
unnecessary to use function, also unnecessary with all those +args

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -137,11 +137,11 @@
 		<div class="box">
 			<h3>Bash</h3>
 			<p>
-				Add this bash function to your <code>~/.bashrc</code> file.
+				Add this bash alias to your <code>~/.bashrc</code> file.
 				The <code>+</code> args show cleaner output from dig.
 			</p>
 			<code class="block">
-				<p>function dy { dig +noall +answer +additional "$@" @dns.toys; }</p>
+				<p>alias dy="dig +short @dns.toys</p>
 			</code>
 
 			<h3>Fish</h3>


### PR DESCRIPTION
I just think all those +args are unnecessary if +short formats it correctly, also in bash there is no need to make a function in order to place the $1 argument in the middle, just put it at the end and use an alias.

This makes it easier for beginners to understand.