### PR TITLE
support for epoch conversions

### DIFF
--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/knadh/dns.toys/internal/services/coin"
 	"github.com/knadh/dns.toys/internal/services/dice"
 	"github.com/knadh/dns.toys/internal/services/dict"
+	"github.com/knadh/dns.toys/internal/services/epoch"
 	"github.com/knadh/dns.toys/internal/services/fx"
 	"github.com/knadh/dns.toys/internal/services/num2words"
 	"github.com/knadh/dns.toys/internal/services/random"
@@ -234,6 +235,14 @@ func main() {
 		h.register("words", n, mux)
 
 		help = append(help, []string{"convert numbers to words.", "dig 123456.words @%s"})
+	}
+
+	// Convert Epoch
+	if ko.Bool("epoch.enabled") {
+		n := epoch.New()
+		h.register("epoch", n, mux)
+
+		help = append(help, []string{"convert epoch to human readable date and time", "dig 784783800.epoch @%s"})
 	}
 
 	// CIDR.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -72,6 +72,9 @@ max_results = 5
 [dice]
 enabled = true
 
+[epoch]
+enabled = true
+
 [coin]
 enabled = true
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,7 +163,13 @@
 		<p>Generate a random number in a specified range (inclusive of the range values).</p>
 	</section>
 
-
+	<section class="box">
+		<h2>Epoch/Unix timestamp conversion</h2>
+		<code class="block">
+			<p>dig 784783800.epoch @dns.toys</p>
+		</code>
+		<p>Convert an epoch/unix timestamp into a human readable date. Supports Unix timestamps in s, ms, µs and ns. </p>
+	</section>
 
 	<section class="box">
 		<h2>Help</h2>

--- a/internal/services/epoch/epoch.go
+++ b/internal/services/epoch/epoch.go
@@ -1,0 +1,43 @@
+// converts an epoch/unix timestamp to human readable form.
+package epoch
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type Epoch struct{}
+
+// New returns a new instance of CIDR.
+func New() *Epoch {
+	return &Epoch{}
+}
+
+// parses the query which is a epoch and returns it in human readable
+func (n *Epoch) Query(q string) ([]string, error) {
+
+	timestamp, err := strconv.ParseInt(q, 10, 64)
+	if err != nil {
+		return nil, errors.New("invalid epoch query")
+	}
+
+	if timestamp >= 1e16 || timestamp <= -1e16 {
+		timestamp = (timestamp / 1000000000) // To handle Nanoseconds
+
+	} else if timestamp >= 1e14 || timestamp <= -1e14 {
+		timestamp = (timestamp / 1000000) // To handle Microseconds
+
+	} else if timestamp >= 1e11 || timestamp <= -3e10 {
+		timestamp = (timestamp / 1000) // To handle Milliseconds
+	}
+	resinutc := time.Unix(timestamp, 0).UTC()
+	resinlocal := time.Unix(timestamp, 0)
+	out := fmt.Sprintf(`%s 1 TXT "%s" "%s"`, q, resinutc, resinlocal)
+	return []string{out}, nil
+}
+
+func (n *Epoch) Dump() ([]byte, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Adds the functionality to convert epoch time to human readable.
```
% dig 784783800.epoch @127.0.0.1 -p 5354

;; QUESTION SECTION:
;784783800.epoch.		IN	A

;; ANSWER SECTION:
784783800.		1	IN	TXT	"1994-11-14 03:30:00 +0000 UTC" "1994-11-14 09:00:00 +0530 IST"
```
closes #39