### PR TITLE
Update deprecated io/ioutil package

### DIFF
--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -106,7 +105,7 @@ func saveSnapshot(h *handlers) {
 
 				filePath := ko.MustString(name + ".snapshot_file")
 				lo.Printf("saving %s snapshot to %s", name, filePath)
-				if err := ioutil.WriteFile(filePath, b, 0644); err != nil {
+				if err := os.WriteFile(filePath, b, 0644); err != nil {
 					lo.Printf("error writing %s snapshot: %v", name, err)
 				}
 			}
@@ -125,7 +124,7 @@ func loadSnapshot(service string) []byte {
 
 	filePath := ko.MustString(service + ".snapshot_file")
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
 			return nil

--- a/internal/services/fx/fx.go
+++ b/internal/services/fx/fx.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"regexp"
@@ -164,7 +164,7 @@ func (fx *FX) load(url string) (data, error) {
 		return data{}, fmt.Errorf("request failed: %v", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return data{}, err
 	}

--- a/internal/services/weather/weather.go
+++ b/internal/services/weather/weather.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"sync"
@@ -268,7 +267,7 @@ func (w *Weather) fetchAPI(lat, lon float64) (entry, error) {
 	}
 	defer func() {
 		// Drain and close the body to let the Transport reuse the connection
-		io.Copy(ioutil.Discard, r.Body)
+		io.Copy(io.Discard, r.Body)
 		r.Body.Close()
 	}()
 
@@ -281,7 +280,7 @@ func (w *Weather) fetchAPI(lat, lon float64) (entry, error) {
 		}
 		defer reader.Close()
 
-		b, err := ioutil.ReadAll(reader)
+		b, err := io.ReadAll(reader)
 		if err != nil {
 			return bad, err
 		}
@@ -289,7 +288,7 @@ func (w *Weather) fetchAPI(lat, lon float64) (entry, error) {
 		body = b
 	} else {
 		defer r.Body.Close()
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			return bad, err
 		}


### PR DESCRIPTION
This PR updates the deprecated io/ioutil package to io and os in accordance with Go 1.16 changes. Functions like ioutil.ReadFile and ioutil.WriteFile are replaced with os.ReadFile and os.WriteFile respectively.