### PR TITLE
Add a sudoku solver service

### DIFF
--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/knadh/dns.toys/internal/services/fx"
 	"github.com/knadh/dns.toys/internal/services/num2words"
 	"github.com/knadh/dns.toys/internal/services/random"
+	"github.com/knadh/dns.toys/internal/services/sudokusolver"
 	"github.com/knadh/dns.toys/internal/services/timezones"
 	"github.com/knadh/dns.toys/internal/services/units"
 	"github.com/knadh/dns.toys/internal/services/uuid"
@@ -322,6 +323,14 @@ func main() {
 		h.register("uuid", u, mux)
 
 		help = append(help, []string{"generate random UUID-v4s", "dig 2.uuid @%s"})
+	}
+
+	// Sudoku Solver
+	if ko.Bool("sudokusolver.enabled") {
+		ssolver := sudokusolver.New()
+		h.register("uuid", ssolver, mux)
+		// enter the sudoku puzzle string in row major format, empty cells should have value 0
+		help = append(help, []string{"solve a sudoku", "dig 002840003076000000100006050030080000007503200000020010080100004000000730700064500.sudokusolver @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -88,3 +88,6 @@ enabled = true
 [uuid]
 enabled = true
 max_results = 25
+
+[sudokusolver]
+enabled = true

--- a/docs/index.html
+++ b/docs/index.html
@@ -200,6 +200,14 @@
 	</section>
 
 	<section class="box">
+		<h2>Solve Sudoku</h2>
+		<code class="block">
+			<p>dig 002840003076000000100006050030080000007503200000020010080100004000000730700064500.sudokusolver @dns.toys</p>
+		</code>
+		<p>Solve Sudoku. send sudoku puzzle string in row major format, empty cells should have value 0 (v4).</p>
+	</section>
+
+	<section class="box">
 		<h2>Help</h2>
 		<code class="block">
 			<p>dig help @dns.toys</p>

--- a/internal/services/sudokusolver/sudokusolver.go
+++ b/internal/services/sudokusolver/sudokusolver.go
@@ -1,0 +1,163 @@
+package sudokusolver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const incorrect_puzzle_string_format = "Incorrect sudoku puzzle string. Puzzle string must be in the row major order. Empty puzzle cells must be replaced with 0 value. The string must consists of only digits [0, 9]. Puzzle string must be of length 81."
+const puzzle_not_solvable = "Puzzle could not be solved."
+
+// stores the starting index of each of the 3x3 blocks. for example first 3x3 block's starting row and column are (0,0)
+// for the last 3x3 block starting row and column are (6, 6)
+var startRowColumn = [][][]int{
+	{[]int{0, 0}, []int{0, 3}, []int{0, 6}},
+	{[]int{3, 0}, []int{3, 3}, []int{3, 6}},
+	{[]int{6, 0}, []int{6, 3}, []int{6, 6}},
+}
+
+type SudokuSolver struct{}
+
+// New returns a new instance of SudokuSolver.
+func New() *SudokuSolver {
+	return &SudokuSolver{}
+}
+
+// Query converts a number to words.
+func (solver *SudokuSolver) Query(q string) ([]string, error) {
+	fmt.Println("given puzzle")
+	puzzle, err := stringToPuzzle(q)
+	if err != nil {
+		return nil, errors.New(incorrect_puzzle_string_format)
+	}
+	if solve(puzzle) {
+		r := fmt.Sprintf(`%s 1 TXT "%s"`, q, puzzleToString(puzzle))
+		return []string{r}, nil
+	}
+	return nil, errors.New(puzzle_not_solvable)
+}
+
+// Dump is not implemented in this package.
+func (n *SudokuSolver) Dump() ([]byte, error) {
+	return nil, nil
+}
+
+// converts string to puzzle which is of type [][]int
+func stringToPuzzle(puzzleString string) ([][]int, error) {
+	if len(puzzleString) != 81 {
+		return nil, fmt.Errorf(incorrect_puzzle_string_format)
+	}
+	puzzle := make([][]int, 0)
+	i, j := 0, -1
+
+	for _, char := range puzzleString {
+		if i%9 == 0 {
+			puzzle = append(puzzle, make([]int, 0))
+			j += 1
+		}
+		k, err := strconv.Atoi(string(char))
+		if err != nil {
+			return nil, fmt.Errorf(incorrect_puzzle_string_format)
+		}
+		puzzle[j] = append(puzzle[j], k)
+		i += 1
+	}
+
+	return puzzle, nil
+}
+
+// finds all the valid options for the cell
+func getOptions(puzzle [][]int, row, col int) []int {
+	var availableOptions = map[int]bool{
+		1: true,
+		2: true,
+		3: true,
+		4: true,
+		5: true,
+		6: true,
+		7: true,
+		8: true,
+		9: true,
+	}
+
+	// finding exclusions along the column
+	for i := 0; i < 9; i++ {
+		temp := puzzle[row][i]
+		if temp != 0 {
+			availableOptions[temp] = false
+		}
+	}
+
+	// finding exclusions along the row
+	for i := 0; i < 9; i++ {
+		temp := puzzle[i][col]
+		if temp != 0 {
+			availableOptions[temp] = false
+		}
+	}
+
+	// finding exclusions in the block
+	startRow, startCol := startRowColumn[int(row/3)][int(col/3)][0], startRowColumn[int(row/3)][int(col/3)][1]
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			temp := puzzle[startRow+i][startCol+j]
+			if temp != 0 {
+				availableOptions[temp] = false
+			}
+		}
+	}
+	options := make([]int, 0)
+	for k, v := range availableOptions {
+		if v {
+			options = append(options, k)
+		}
+	}
+
+	return options
+}
+
+// solves the sudoku puzzle
+func solve(puzzle [][]int) bool {
+	for row := 0; row < 9; row++ {
+		for col := 0; col < 9; col++ {
+			if puzzle[row][col] == 0 {
+				options := getOptions(puzzle, row, col)
+				for _, opt := range options {
+					puzzle[row][col] = opt
+					if solve(puzzle) {
+						return true
+					} else {
+						puzzle[row][col] = 0
+					}
+				}
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// converts puzzle which is of type [][]int back to string for response
+func puzzleToString(puzzle [][]int) string {
+	rowStrings := make([]string, 0)
+	for _, row := range puzzle {
+		for _, val := range row {
+			rowStrings = append(rowStrings, fmt.Sprintf("%d", val))
+		}
+	}
+	return strings.Join(rowStrings, "")
+}
+
+// only for visualization purpose
+func printPuzzle(puzzle [][]int) {
+	rowString := ""
+	for row := 0; row < 9; row++ {
+		for col := 0; col < 9; col++ {
+			rowString += fmt.Sprintf("%d ", puzzle[row][col])
+		}
+		rowString += "\n"
+	}
+	fmt.Printf(rowString)
+}


### PR DESCRIPTION
 This feature introduces Sudoku-solving capability.
A Sudoku puzzle string is represented by cell values in a row-major format, where empty cells are denoted by the value 0. For instance, 
![sudoku](https://github.com/knadh/dns.toys/assets/141809772/d53351af-d09c-43fe-b9d3-a641508d18c1)

The corresponding puzzle string would be: : `080000005000835410903407820700000600100509002006000003018302907047698000300000040`

Running this through the feature yields the output: `481926375672835419953417826725183694134569782896274153518342967247698531369751248`

@knadh, do you find this addition useful and worthy of inclusion?