### PR TITLE
feat: add dns caching for queries

### DIFF
--- a/cmd/dnstoys/handlers.go
+++ b/cmd/dnstoys/handlers.go
@@ -109,8 +109,9 @@ func (h *handlers) handleEchoIP(w dns.ResponseWriter, r *dns.Msg) {
 
 		switch {
 		// Handle ipv4.
+		// TTL is set to 60 seconds (1 Minute).
 		case ip.To4() != nil:
-			rr, err := dns.NewRR(fmt.Sprintf("ip. 1 TXT \"%s\"", ip.To4().String()))
+			rr, err := dns.NewRR(fmt.Sprintf("ip. 60 TXT \"%s\"", ip.To4().String()))
 			if err != nil {
 				lo.Printf("error preparing ip response: %v", err)
 				return
@@ -118,7 +119,7 @@ func (h *handlers) handleEchoIP(w dns.ResponseWriter, r *dns.Msg) {
 			m.Answer = append(m.Answer, rr)
 		// Handle ipv6.
 		case ip.To16() != nil:
-			rr, err := dns.NewRR(fmt.Sprintf("ip. 1 TXT \"%s\"", ip.To16().String()))
+			rr, err := dns.NewRR(fmt.Sprintf("ip. 60 TXT \"%s\"", ip.To16().String()))
 			if err != nil {
 				lo.Printf("error preparing ip response: %v", err)
 				return
@@ -134,6 +135,7 @@ func (h *handlers) handleEchoIP(w dns.ResponseWriter, r *dns.Msg) {
 // TXT  record: "3.141592653589793238462643383279502884197169"
 // A    record: 3.141.59.27
 // AAAA record: 3141:5926:5358:9793:2384:6264:3383:2795
+// TTL is set to 1 year (60*60*24*365 = 3,15,36,000).
 func (h *handlers) handlePi(w dns.ResponseWriter, r *dns.Msg) {
 	m := &dns.Msg{}
 	m.SetReply(r)
@@ -142,7 +144,7 @@ func (h *handlers) handlePi(w dns.ResponseWriter, r *dns.Msg) {
 	for _, q := range m.Question {
 		var rrstr string
 		if q.Qtype == dns.TypeTXT {
-			rrstr = "pi. 1 TXT 3.141592653589793238462643383279502884197169"
+			rrstr = "pi. 31536000 TXT 3.141592653589793238462643383279502884197169"
 		} else if q.Qtype == dns.TypeA {
 			rrstr = "pi. IN A 3.141.59.27"
 		} else if q.Qtype == dns.TypeAAAA {

--- a/cmd/dnstoys/handlers.go
+++ b/cmd/dnstoys/handlers.go
@@ -26,6 +26,13 @@ type handlers struct {
 
 var reClean = regexp.MustCompile("[^a-zA-Z0-9/\\-\\.:,]")
 
+const (
+	// TTL is set to 60 seconds (1 Minute).
+	IP_TTL = 60
+	// TTL is set to 1 year (60*60*24*365 = 3,15,36,000).
+	PI_TTL = 31536000
+)
+
 // register registers a Service for a given query suffix on the DNS server.
 // A Service responds to a DNS query via Query().
 func (h *handlers) register(suffix string, s Service, mux *dns.ServeMux) func(w dns.ResponseWriter, r *dns.Msg) {
@@ -109,9 +116,8 @@ func (h *handlers) handleEchoIP(w dns.ResponseWriter, r *dns.Msg) {
 
 		switch {
 		// Handle ipv4.
-		// TTL is set to 60 seconds (1 Minute).
 		case ip.To4() != nil:
-			rr, err := dns.NewRR(fmt.Sprintf("ip. 60 TXT \"%s\"", ip.To4().String()))
+			rr, err := dns.NewRR(fmt.Sprintf("ip. %d TXT \"%s\"", IP_TTL, ip.To4().String()))
 			if err != nil {
 				lo.Printf("error preparing ip response: %v", err)
 				return
@@ -119,7 +125,7 @@ func (h *handlers) handleEchoIP(w dns.ResponseWriter, r *dns.Msg) {
 			m.Answer = append(m.Answer, rr)
 		// Handle ipv6.
 		case ip.To16() != nil:
-			rr, err := dns.NewRR(fmt.Sprintf("ip. 60 TXT \"%s\"", ip.To16().String()))
+			rr, err := dns.NewRR(fmt.Sprintf("ip. %d TXT \"%s\"",IP_TTL, ip.To16().String()))
 			if err != nil {
 				lo.Printf("error preparing ip response: %v", err)
 				return
@@ -135,7 +141,6 @@ func (h *handlers) handleEchoIP(w dns.ResponseWriter, r *dns.Msg) {
 // TXT  record: "3.141592653589793238462643383279502884197169"
 // A    record: 3.141.59.27
 // AAAA record: 3141:5926:5358:9793:2384:6264:3383:2795
-// TTL is set to 1 year (60*60*24*365 = 3,15,36,000).
 func (h *handlers) handlePi(w dns.ResponseWriter, r *dns.Msg) {
 	m := &dns.Msg{}
 	m.SetReply(r)
@@ -144,11 +149,11 @@ func (h *handlers) handlePi(w dns.ResponseWriter, r *dns.Msg) {
 	for _, q := range m.Question {
 		var rrstr string
 		if q.Qtype == dns.TypeTXT {
-			rrstr = "pi. 31536000 TXT 3.141592653589793238462643383279502884197169"
+			rrstr = fmt.Sprintf("pi. %d TXT 3.141592653589793238462643383279502884197169", PI_TTL)
 		} else if q.Qtype == dns.TypeA {
-			rrstr = "pi. IN A 3.141.59.27"
+			rrstr = fmt.Sprintf("pi. %d IN A 3.141.59.27", PI_TTL)
 		} else if q.Qtype == dns.TypeAAAA {
-			rrstr = "pi. IN AAAA 3141:5926:5358:9793:2384:6264:3383:2795"
+			rrstr = fmt.Sprintf("pi. %d IN AAAA 3141:5926:5358:9793:2384:6264:3383:2795", PI_TTL)
 		} else {
 			continue
 		}

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -333,8 +333,9 @@ func main() {
 	}
 
 	// Prepare the static help response for the `help` query.
+	// TTL is set to 1 day (60*60*24 = 86,400).
 	for _, l := range help {
-		r, err := dns.NewRR(fmt.Sprintf("help. 1 TXT \"%s\" \"%s\"", l[0], fmt.Sprintf(l[1], h.domain)))
+		r, err := dns.NewRR(fmt.Sprintf("help. 86400 TXT \"%s\" \"%s\"", l[0], fmt.Sprintf(l[1], h.domain)))
 		if err != nil {
 			lo.Fatalf("error preparing: %v", err)
 		}

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -41,6 +41,9 @@ var (
 	buildString = "unknown"
 )
 
+// TTL is set to 1 day (60*60*24 = 86,400).
+const HELP_TTL = 86400
+
 // Not all platforms have syscall.SIGUNUSED so use Golang's default definition here
 const SIGUNUSED = syscall.Signal(0x1f)
 
@@ -333,9 +336,8 @@ func main() {
 	}
 
 	// Prepare the static help response for the `help` query.
-	// TTL is set to 1 day (60*60*24 = 86,400).
 	for _, l := range help {
-		r, err := dns.NewRR(fmt.Sprintf("help. 86400 TXT \"%s\" \"%s\"", l[0], fmt.Sprintf(l[1], h.domain)))
+		r, err := dns.NewRR(fmt.Sprintf("help. %d TXT \"%s\" \"%s\"", HELP_TTL, l[0], fmt.Sprintf(l[1], h.domain)))
 		if err != nil {
 			lo.Fatalf("error preparing: %v", err)
 		}

--- a/internal/services/aerial/aerial.go
+++ b/internal/services/aerial/aerial.go
@@ -59,9 +59,9 @@ func (a *Aerial) Query(q string) ([]string, error) {
 	if e != nil {
 		return nil, e
 	}
-
+	// TTL is set to 900 seconds (15 minutes).
 	result := "aerial distance = " + strconv.FormatFloat(d, 'f', 2, 64) + " KM"
-	r := fmt.Sprintf(`%s 1 TXT "%s"`, q, result)
+	r := fmt.Sprintf(`%s 900 TXT "%s"`, q, result)
 
 	return []string{r}, nil
 }

--- a/internal/services/aerial/aerial.go
+++ b/internal/services/aerial/aerial.go
@@ -18,6 +18,8 @@ type Location struct {
 const (
 	delimiter = ","
 	separator = "/"
+	// TTL is set to 900 seconds (15 minutes).
+	TTL = 900
 )
 
 var (
@@ -59,9 +61,8 @@ func (a *Aerial) Query(q string) ([]string, error) {
 	if e != nil {
 		return nil, e
 	}
-	// TTL is set to 900 seconds (15 minutes).
 	result := "aerial distance = " + strconv.FormatFloat(d, 'f', 2, 64) + " KM"
-	r := fmt.Sprintf(`%s 900 TXT "%s"`, q, result)
+	r := fmt.Sprintf(`%s %d TXT "%s"`, q, TTL, result)
 
 	return []string{r}, nil
 }

--- a/internal/services/base/base.go
+++ b/internal/services/base/base.go
@@ -51,7 +51,8 @@ func (n *Base) Query(q string) ([]string, error) {
 
 	res := strconv.FormatInt(num, toBase)
 
-	r := fmt.Sprintf("%s 1 TXT \"%s %s = %s %s\"", q, reg[1], reg[2], res, reg[3])
+	// TTL is set to 900 seconds (15 minutes).
+	r := fmt.Sprintf("%s 900 TXT \"%s %s = %s %s\"", q, reg[1], reg[2], res, reg[3])
 	return []string{r}, nil
 }
 

--- a/internal/services/base/base.go
+++ b/internal/services/base/base.go
@@ -24,6 +24,9 @@ var baseStrToNum = map[string]int{
 	"bin": 2,
 }
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 // Query converts a number from one base to another base format
 func (n *Base) Query(q string) ([]string, error) {
 
@@ -51,8 +54,7 @@ func (n *Base) Query(q string) ([]string, error) {
 
 	res := strconv.FormatInt(num, toBase)
 
-	// TTL is set to 900 seconds (15 minutes).
-	r := fmt.Sprintf("%s 900 TXT \"%s %s = %s %s\"", q, reg[1], reg[2], res, reg[3])
+	r := fmt.Sprintf("%s %d TXT \"%s %s = %s %s\"", q, TTL, reg[1], reg[2], res, reg[3])
 	return []string{r}, nil
 }
 

--- a/internal/services/cidr/cidr.go
+++ b/internal/services/cidr/cidr.go
@@ -15,6 +15,9 @@ func New() *CIDR {
 	return &CIDR{}
 }
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 // Query parses a given query string and returns the answer.
 // For the cidr package, the query is an IP Address Prefix (CIDR notation).
 func (c *CIDR) Query(q string) ([]string, error) {
@@ -52,8 +55,7 @@ func (c *CIDR) Query(q string) ([]string, error) {
 		// Get the size of subnet.
 		size := 1 << (uint64(bits) - uint64(prefixLen))
 
-		// TTL is set to 900 seconds (15 minutes).
-		r := fmt.Sprintf("%s 900 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
+		r := fmt.Sprintf("%s %d TXT \"%s\" \"%s\" \"%d\"", q, TTL, first, last, size)
 		return []string{r}, nil
 
 	// Handle ipv6.
@@ -72,8 +74,7 @@ func (c *CIDR) Query(q string) ([]string, error) {
 		size := big.NewInt(1)
 		size = size.Lsh(size, uint(bits-prefixLen))
 
-		// TTL is set to 900 seconds (15 minutes).
-		r := fmt.Sprintf("%s 900 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
+		r := fmt.Sprintf("%s %d TXT \"%s\" \"%s\" \"%d\"", q, TTL, first, last, size)
 		return []string{r}, nil
 
 	default:

--- a/internal/services/cidr/cidr.go
+++ b/internal/services/cidr/cidr.go
@@ -52,7 +52,8 @@ func (c *CIDR) Query(q string) ([]string, error) {
 		// Get the size of subnet.
 		size := 1 << (uint64(bits) - uint64(prefixLen))
 
-		r := fmt.Sprintf("%s 1 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
+		// TTL is set to 900 seconds (15 minutes).
+		r := fmt.Sprintf("%s 900 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
 		return []string{r}, nil
 
 	// Handle ipv6.
@@ -71,7 +72,8 @@ func (c *CIDR) Query(q string) ([]string, error) {
 		size := big.NewInt(1)
 		size = size.Lsh(size, uint(bits-prefixLen))
 
-		r := fmt.Sprintf("%s 1 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
+		// TTL is set to 900 seconds (15 minutes).
+		r := fmt.Sprintf("%s 900 TXT \"%s\" \"%s\" \"%d\"", q, first, last, size)
 		return []string{r}, nil
 
 	default:

--- a/internal/services/dict/dict.go
+++ b/internal/services/dict/dict.go
@@ -125,11 +125,12 @@ func (d *Dict) get(q string) ([]string, error) {
 			group[p] = group[p][0:d.opt.MaxResults]
 		}
 
+		// TTL is set to 900 seconds (15 minutes).
 		for _, entry := range group[p] {
 			if len(entry.example) > 0 {
-				out = append(out, fmt.Sprintf("%s 1 TXT \"%s\" \"%s\" \"eg: '%s'\"", original, posMap[p], entry.meaning, entry.example))
+				out = append(out, fmt.Sprintf("%s 900 TXT \"%s\" \"%s\" \"eg: '%s'\"", original, posMap[p], entry.meaning, entry.example))
 			} else {
-				out = append(out, fmt.Sprintf("%s 1 TXT \"%s\" \"%s\"", original, posMap[p], entry.meaning))
+				out = append(out, fmt.Sprintf("%s 900 TXT \"%s\" \"%s\"", original, posMap[p], entry.meaning))
 			}
 		}
 	}

--- a/internal/services/dict/dict.go
+++ b/internal/services/dict/dict.go
@@ -15,6 +15,8 @@ const (
 	Adjective = wnram.Adjective
 	Adverb    = wnram.Adverb
 	Noun      = wnram.Noun
+	// TTL is set to 900 seconds (15 minutes).
+	TTL = 900
 )
 
 type clusterGroupItem struct {
@@ -125,12 +127,11 @@ func (d *Dict) get(q string) ([]string, error) {
 			group[p] = group[p][0:d.opt.MaxResults]
 		}
 
-		// TTL is set to 900 seconds (15 minutes).
 		for _, entry := range group[p] {
 			if len(entry.example) > 0 {
-				out = append(out, fmt.Sprintf("%s 900 TXT \"%s\" \"%s\" \"eg: '%s'\"", original, posMap[p], entry.meaning, entry.example))
+				out = append(out, fmt.Sprintf("%s %d TXT \"%s\" \"%s\" \"eg: '%s'\"", original, TTL, posMap[p], entry.meaning, entry.example))
 			} else {
-				out = append(out, fmt.Sprintf("%s 900 TXT \"%s\" \"%s\"", original, posMap[p], entry.meaning))
+				out = append(out, fmt.Sprintf("%s %d TXT \"%s\" \"%s\"", original, TTL, posMap[p], entry.meaning))
 			}
 		}
 	}

--- a/internal/services/epoch/epoch.go
+++ b/internal/services/epoch/epoch.go
@@ -17,6 +17,9 @@ func New(localTime bool) *Epoch {
 	return &Epoch{localTime: localTime}
 }
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 // parses the query which is a epoch and returns it in human readable
 func (e *Epoch) Query(q string) ([]string, error) {
 	ts, err := strconv.ParseInt(q, 10, 64)
@@ -42,8 +45,7 @@ func (e *Epoch) Query(q string) ([]string, error) {
 		local = time.Unix(ts, 0)
 	)
 
-	// TTL is set to 900 seconds (15 minutes).
-	out := fmt.Sprintf(`%s 900 TXT "%s"`, q, utc)
+	out := fmt.Sprintf(`%s %d TXT "%s"`, q, TTL, utc)
 	if e.localTime {
 		out += ` "` + local.String() + `"`
 	}

--- a/internal/services/epoch/epoch.go
+++ b/internal/services/epoch/epoch.go
@@ -42,7 +42,8 @@ func (e *Epoch) Query(q string) ([]string, error) {
 		local = time.Unix(ts, 0)
 	)
 
-	out := fmt.Sprintf(`%s 1 TXT "%s"`, q, utc)
+	// TTL is set to 900 seconds (15 minutes).
+	out := fmt.Sprintf(`%s 900 TXT "%s"`, q, utc)
 	if e.localTime {
 		out += ` "` + local.String() + `"`
 	}

--- a/internal/services/fx/fx.go
+++ b/internal/services/fx/fx.go
@@ -120,7 +120,8 @@ func (fx *FX) Query(q string) ([]string, error) {
 	// Convert.
 	conv := (baseRate / fromRate) / (baseRate / toRate) * val
 
-	r := fmt.Sprintf("%s TXT \"%0.2f %s = %0.2f %s\" \"%s\"", q, val, from, conv, to, fx.data.Date)
+	// TTL is set to 900 seconds (15 minutes).
+	r := fmt.Sprintf("%s 900 TXT \"%0.2f %s = %0.2f %s\" \"%s\"", q, val, from, conv, to, fx.data.Date)
 
 	return []string{r}, nil
 }

--- a/internal/services/fx/fx.go
+++ b/internal/services/fx/fx.go
@@ -19,6 +19,9 @@ import (
 
 const apiURL = "https://open.er-api.com/v6/latest/USD"
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 var reParse = regexp.MustCompile("([0-9\\.]+)([A-Z]{3})\\-([A-Z]{3})")
 
 // FX represents the currency coversion (Foreign Exchange) package.
@@ -120,8 +123,7 @@ func (fx *FX) Query(q string) ([]string, error) {
 	// Convert.
 	conv := (baseRate / fromRate) / (baseRate / toRate) * val
 
-	// TTL is set to 900 seconds (15 minutes).
-	r := fmt.Sprintf("%s 900 TXT \"%0.2f %s = %0.2f %s\" \"%s\"", q, val, from, conv, to, fx.data.Date)
+	r := fmt.Sprintf("%s %d TXT \"%0.2f %s = %0.2f %s\" \"%s\"", q, TTL, val, from, conv, to, fx.data.Date)
 
 	return []string{r}, nil
 }

--- a/internal/services/num2words/num2words.go
+++ b/internal/services/num2words/num2words.go
@@ -44,7 +44,8 @@ func (n *Num2Words) Query(q string) ([]string, error) {
 		w += " Point" + decimal2words(decimalValue)
 	}
 
-	r := fmt.Sprintf("%s 1 TXT \"%g = %s\"", q, num, w)
+	// TTL is set to 900 seconds (15 minutes).
+	r := fmt.Sprintf("%s 900 TXT \"%g = %s\"", q, num, w)
 	return []string{r}, nil
 }
 

--- a/internal/services/num2words/num2words.go
+++ b/internal/services/num2words/num2words.go
@@ -23,6 +23,9 @@ var (
 	}
 )
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 type Num2Words struct{}
 
 // New returns a new instance of Num2Words.
@@ -44,8 +47,7 @@ func (n *Num2Words) Query(q string) ([]string, error) {
 		w += " Point" + decimal2words(decimalValue)
 	}
 
-	// TTL is set to 900 seconds (15 minutes).
-	r := fmt.Sprintf("%s 900 TXT \"%g = %s\"", q, num, w)
+	r := fmt.Sprintf("%s %d TXT \"%g = %s\"", q, TTL, num, w)
 	return []string{r}, nil
 }
 

--- a/internal/services/sudoku/sudoku.go
+++ b/internal/services/sudoku/sudoku.go
@@ -32,7 +32,8 @@ func (s *Sudoku) Query(q string) ([]string, error) {
 	}
 
 	if s.solvePuzzle(puzzle) {
-		return []string{fmt.Sprintf(`%s 1 TXT "%s"`, q, s.puzzleToString(puzzle))}, nil
+		// TTL is set to 900 seconds (15 minutes).
+		return []string{fmt.Sprintf(`%s 900 TXT "%s"`, q, s.puzzleToString(puzzle))}, nil
 	}
 
 	return nil, errors.New("puzzle could not be solved.")

--- a/internal/services/sudoku/sudoku.go
+++ b/internal/services/sudoku/sudoku.go
@@ -17,6 +17,9 @@ var startRowColumns = [][][]int{
 	{[]int{6, 0}, []int{6, 3}, []int{6, 6}},
 }
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 type Sudoku struct{}
 
 // New returns a new instance of Sudoku.
@@ -32,8 +35,7 @@ func (s *Sudoku) Query(q string) ([]string, error) {
 	}
 
 	if s.solvePuzzle(puzzle) {
-		// TTL is set to 900 seconds (15 minutes).
-		return []string{fmt.Sprintf(`%s 900 TXT "%s"`, q, s.puzzleToString(puzzle))}, nil
+		return []string{fmt.Sprintf(`%s %d TXT "%s"`, q, TTL, s.puzzleToString(puzzle))}, nil
 	}
 
 	return nil, errors.New("puzzle could not be solved.")

--- a/internal/services/units/units.go
+++ b/internal/services/units/units.go
@@ -41,6 +41,9 @@ type Units struct {
 	help []string
 }
 
+// TTL is set to 900 seconds (15 minutes).
+const TTL = 900
+
 //go:embed units.json
 var dataB []byte
 
@@ -127,9 +130,8 @@ func (u *Units) Query(q string) ([]string, error) {
 	// Convert.
 	conv := (baseRate / from.Value) / (baseRate / to.Value) * val
 
-	// TTL is set to 900 seconds (15 minutes).
-	r := fmt.Sprintf("%s 900 TXT \"%0.2f %s (%s) = %0.2f %s (%s)\"",
-		q, val, from.Name, from.Symbol, conv, to.Name, to.Symbol)
+	r := fmt.Sprintf("%s %d TXT \"%0.2f %s (%s) = %0.2f %s (%s)\"",
+		q, TTL, val, from.Name, from.Symbol, conv, to.Name, to.Symbol)
 
 	return []string{r}, nil
 }
@@ -168,8 +170,7 @@ func (u *Units) printUnitsList() []string {
 		})
 
 		for _, un := range list {
-			// TTL is set to 900 seconds (15 minutes).
-			l := fmt.Sprintf("unit. 900 \"%s\" \"%s (%s)\"", g, un.Symbol, un.Name)
+			l := fmt.Sprintf("unit. %d \"%s\" \"%s (%s)\"", TTL, g, un.Symbol, un.Name)
 			out = append(out, l)
 		}
 	}

--- a/internal/services/units/units.go
+++ b/internal/services/units/units.go
@@ -127,7 +127,8 @@ func (u *Units) Query(q string) ([]string, error) {
 	// Convert.
 	conv := (baseRate / from.Value) / (baseRate / to.Value) * val
 
-	r := fmt.Sprintf("%s 1 TXT \"%0.2f %s (%s) = %0.2f %s (%s)\"",
+	// TTL is set to 900 seconds (15 minutes).
+	r := fmt.Sprintf("%s 900 TXT \"%0.2f %s (%s) = %0.2f %s (%s)\"",
 		q, val, from.Name, from.Symbol, conv, to.Name, to.Symbol)
 
 	return []string{r}, nil
@@ -167,7 +168,8 @@ func (u *Units) printUnitsList() []string {
 		})
 
 		for _, un := range list {
-			l := fmt.Sprintf("unit. 1 TXT \"%s\" \"%s (%s)\"", g, un.Symbol, un.Name)
+			// TTL is set to 900 seconds (15 minutes).
+			l := fmt.Sprintf("unit. 900 \"%s\" \"%s (%s)\"", g, un.Symbol, un.Name)
 			out = append(out, l)
 		}
 	}

--- a/internal/services/weather/weather.go
+++ b/internal/services/weather/weather.go
@@ -22,6 +22,9 @@ const (
 
 	// Max requests/sec allowed by the API.
 	apiRateLimit = 15
+
+	// TTL is set to 1 hour (60*60=3,600).
+	TTL = 3600
 )
 
 type entry struct {
@@ -154,9 +157,8 @@ func (w *Weather) Query(q string) ([]string, error) {
 		}
 
 		for _, f := range data.Forecasts {
-			// TTL is set to 1 hour (60*60=3,600).
-			r := fmt.Sprintf("%s 3600 TXT \"%s (%s)\" \"%0.2fC (%0.2fF)\" \"%0.2f%% hu.\" \"%s\" \"%s\"",
-				q, l.Name, l.Country, f.TempC, f.TempF, f.Humidity, f.Forecast1H, f.Time.In(zone).Format("15:04, Mon"))
+			r := fmt.Sprintf("%s %d TXT \"%s (%s)\" \"%0.2fC (%0.2fF)\" \"%0.2f%% hu.\" \"%s\" \"%s\"",
+				q, TTL, l.Name, l.Country, f.TempC, f.TempF, f.Humidity, f.Forecast1H, f.Time.In(zone).Format("15:04, Mon"))
 			out = append(out, r)
 		}
 

--- a/internal/services/weather/weather.go
+++ b/internal/services/weather/weather.go
@@ -154,7 +154,8 @@ func (w *Weather) Query(q string) ([]string, error) {
 		}
 
 		for _, f := range data.Forecasts {
-			r := fmt.Sprintf("%s 1 TXT \"%s (%s)\" \"%0.2fC (%0.2fF)\" \"%0.2f%% hu.\" \"%s\" \"%s\"",
+			// TTL is set to 1 hour (60*60=3,600).
+			r := fmt.Sprintf("%s 3600 TXT \"%s (%s)\" \"%0.2fC (%0.2fF)\" \"%0.2f%% hu.\" \"%s\" \"%s\"",
 				q, l.Name, l.Country, f.TempC, f.TempF, f.Humidity, f.Forecast1H, f.Time.In(zone).Format("15:04, Mon"))
 			out = append(out, r)
 		}


### PR DESCRIPTION
This PR adds DNS caching for queries. The TTL is set differently for different queries.
- IP Address -> 60 seconds
- Pi -> 1 year
- Help -> 1 day
- Weather -> 1 hour (pending response has 1 second TTL)

Other calculated queries have 15 minute caching
- Aerial Distance -> 15 minutes
- Base Conversion -> 15 minutes
- CIDR -> 15 minutes
- Dict -> 15 minutes
- Epoch -> 15 minutes
- Currency Conversion -> 15 minutes
- Num2Words -> 15 minutes
- Sudoku -> 15 minutes
- Unit Conversion -> 15 minutes

Error response has still 1 second TTL.

Values can be changed if required.

Thanks for this amazing tool.