### PR TITLE
Feat: Developer excuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ dig 100dec-hex.base @dns.toys
 
 dig fun.dict @dns.toys
 
+dig excuse @dns.toys
+
 dig A12.9352,77.6245/12.9698,77.7500.aerial @dns.toys
 ```
 

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/knadh/dns.toys/internal/services/dice"
 	"github.com/knadh/dns.toys/internal/services/dict"
 	"github.com/knadh/dns.toys/internal/services/epoch"
+	"github.com/knadh/dns.toys/internal/services/excuse"
 	"github.com/knadh/dns.toys/internal/services/fx"
 	"github.com/knadh/dns.toys/internal/services/num2words"
 	"github.com/knadh/dns.toys/internal/services/random"
@@ -333,6 +334,16 @@ func main() {
 		h.register("sudoku", ssolver, mux)
 		// enter the sudoku puzzle string in row major format, each row separated by a dot, empty cells should have value 0
 		help = append(help, []string{"solve a sudoku puzzle", "dig 002840003.076000000.100006050.030080000.007503200.000020010.080100004.000000730.700064500.sudoku @%s"})
+	}
+
+	// Developer Excuse
+	if ko.Bool("excuse.enabled") {
+		e, err := excuse.New()
+		if err != nil {
+			lo.Fatalf("error initializing units service: %v", err)
+		}
+		h.register("excuse", e, mux)
+		help = append(help, []string{"return a developer excuse", "dig excuse @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -91,3 +91,6 @@ max_results = 25
 
 [sudoku]
 enabled = true
+
+[excuse]
+enabled = true

--- a/docs/index.html
+++ b/docs/index.html
@@ -208,6 +208,14 @@
 	</section>
 
 	<section class="box">
+		<h2>Developer Excuse</h2>
+		<code class="block">
+			<p>dig excuse @dns.toys</p>
+		</code>
+		<p>Return a developer excuse.</p>
+	</section>
+
+	<section class="box">
 		<h2>Help</h2>
 		<code class="block">
 			<p>dig help @dns.toys</p>

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -196,5 +196,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/services/excuse/excuse.go
+++ b/internal/services/excuse/excuse.go
@@ -1,0 +1,77 @@
+package excuse
+
+import (
+	"crypto/rand"
+	_ "embed"
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"math/big"
+)
+
+type excuse struct {
+	ID     int    `yaml:"id"`
+	TextEn string `yaml:"text_en"`
+}
+
+type Excuse struct {
+	excuses []excuse `yaml:",flow"`
+}
+
+//go:embed excuses.yml
+var dataB []byte
+
+// New returns a new instance of Excuse.
+func New() (*Excuse, error) {
+	e := &Excuse{
+		excuses: make([]excuse, 0),
+	}
+
+	if err := e.load(); err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+func (e *Excuse) Query(q string) ([]string, error) {
+	result, err := e.randomExcuse()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching excuse: %w", err)
+	}
+
+	out := []string{
+		fmt.Sprintf(`%s 1 TXT "%s"`, q, result),
+	}
+
+	return out, nil
+}
+
+func (e *Excuse) Dump() ([]byte, error) {
+	return nil, nil
+}
+
+func (e *Excuse) load() error {
+	if err := yaml.Unmarshal(dataB, &e.excuses); err != nil {
+		return fmt.Errorf("failed to unmarshal data: %w", err)
+	}
+
+	return nil
+}
+
+// randomExcuse returns a random excuse from the slice.
+func (e *Excuse) randomExcuse() (string, error) {
+	if len(e.excuses) == 0 {
+		return "", fmt.Errorf("cannot pick from empty slice")
+	}
+
+	// Get a random number in range [0, len(slice))
+	max := big.NewInt(int64(len(e.excuses)))
+	res, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate random number: %w", err)
+	}
+
+	// Convert to int since we know it's within bounds
+	index := int(res.Int64())
+	return e.excuses[index].TextEn, nil
+}

--- a/internal/services/excuse/excuse.go
+++ b/internal/services/excuse/excuse.go
@@ -8,13 +8,14 @@ import (
 	"math/big"
 )
 
+// excuse represents a single excuse.
 type excuse struct {
 	ID     int    `yaml:"id"`
 	TextEn string `yaml:"text_en"`
 }
 
 type Excuse struct {
-	excuses []excuse `yaml:",flow"`
+	excuses []excuse
 }
 
 //go:embed excuses.yml
@@ -58,7 +59,7 @@ func (e *Excuse) load() error {
 	return nil
 }
 
-// randomExcuse returns a random excuse from the slice.
+// randomExcuse returns a random excuse from the list of excuses.
 func (e *Excuse) randomExcuse() (string, error) {
 	if len(e.excuses) == 0 {
 		return "", fmt.Errorf("cannot pick from empty slice")
@@ -71,7 +72,5 @@ func (e *Excuse) randomExcuse() (string, error) {
 		return "", fmt.Errorf("failed to generate random number: %w", err)
 	}
 
-	// Convert to int since we know it's within bounds
-	index := int(res.Int64())
-	return e.excuses[index].TextEn, nil
+	return e.excuses[int(res.Int64())].TextEn, nil
 }

--- a/internal/services/excuse/excuses.yml
+++ b/internal/services/excuse/excuses.yml
@@ -1,3 +1,13 @@
+# Description: Excuses for developers
+# Source:
+#  - https://github.com/michelegera/devexcuses-api
+#  - https://github.com/thecatontheflat/excuses
+#  - https://github.com/afreeorange/developer-excuses
+#  - https://github.com/lnfnunes/WFH-excuses
+#  - https://gist.github.com/fortytw2/78f5f9ef915cb43a3be4
+#  - https://github.com/GabrielCrackPro/developer-excuses-app
+
+
 - id: 1
   text_en: "Actually, that's a feature."
 - id: 2
@@ -454,3 +464,289 @@
   text_en: "We've not been able to reproduce the problem."
 - id: 228
   text_en: "We've not received any error notifications."
+- id: 229
+  text_en: "The accounting department made me put that there."
+- id: 230
+  text_en: "The sales department made me do it that way."
+- id: 231
+  text_en: "The accounting department made me do it that way."
+- id: 232
+  text_en: "The sales department made me put that there."
+- id: 233
+  text_en: "The accounting department asked it to be that way."
+- id: 234
+  text_en: "The sales department asked for it to be that way."
+- id: 235
+  text_en: "That must be an accounting department error."
+- id: 236
+  text_en: "That must be a sales department error."
+- id: 237
+  text_en: "Man, I am not that type of a person!"
+- id: 238
+  text_en: "Someone must have left some test code in."
+- id: 239
+  text_en: "The client requested an XML response, but JSON is clearly better."
+- id: 240
+  text_en: "The dev that worked here for a week? Yeah, he wrote that."
+- id: 241
+  text_en: "But we are in a startup, what would you expect?"
+- id: 242
+  text_en: "I forgot my computer."
+- id: 243
+  text_en: "The stakeholder was sick."
+- id: 244
+  text_en: "Everyone was sick."
+- id: 245
+  text_en: "I've a Dr appointment this morning at 10h40 hence I'll WFH."
+- id: 246
+  text_en: "I'm not feeling very well today hence I'll WFH."
+- id: 247
+  text_en: "I will be WFH tomorrow from 7am since my plane is leaving at 5pm."
+- id: 248
+  text_en: "I'm WFH due to an unexpected situation at home."
+- id: 249
+  text_en: "WFH: Car trouble yesterday and today. Punctured tire, replaced and alignment today."
+- id: 250
+  text_en: "I am very unwell and have lost my voice since last evening. I will be WFH today."
+- id: 251
+  text_en: "Will be WFH rest of day. Need to catch a flight shortly after work."
+- id: 252
+  text_en: "I'm WFH today again, my stomach is still feeling weird."
+- id: 253
+  text_en: "WFH Back to the tire shop to install tire and do alignment before lunch hour today."
+- id: 254
+  text_en: "I'm not feeling very well today. I'll WFH and will be available by all usual means."
+- id: 255
+  text_en: "I'll be WFH on Thursday. Wife is getting her wisdom teeth out that morning."
+- id: 256
+  text_en: "I will be WFH today, kids are off this week."
+- id: 257
+  text_en: "It's raining and my car is far away. WFH."
+- id: 258
+  text_en: "WFH today, car is at the mechanic getting fixed for inspection."
+- id: 259
+  text_en: "We lost our apartment keys last night and got locked out! We just entered into apartment by borrowing spare key from Leasing office. I will WFH in the morning session."
+- id: 260
+  text_en: "My daughter's daycare is closed today due to some emergency work in center so I'll WFH."
+- id: 261
+  text_en: "I've an appointment at DMV office this afternoon hence I'll WFH today."
+- id: 262
+  text_en: "I got flu and is WFH today as I am feverish and got body pain. I will be connected and available over phone and slack too."
+- id: 263
+  text_en: "I will be WFH today, my kids are sick and I need to look after them."
+- id: 264
+  text_en: "I woke up late, that's why I am WFH today."
+- id: 265
+  text_en: "I will be WFH because I'm waiting a shipment to arrive today."
+- id: 266
+  text_en: "My dog is sick, so I'm going to WFH today."
+- id: 267
+  text_en: "A company is going to do pest control here in my house and I will have to stay here to give them assistance, I'll be WFH."
+- id: 268
+  text_en: "The internet provider is coming to repair my network so I'll WFH today."
+- id: 269
+  text_en: "My grandmother poisoned me with ham! WFH today."
+- id: 270
+  text_en: "Don't worry, that value is only wrong half of the time."
+- id: 271
+  text_en: "I can have a look but there's a lot of if statements in that code!"
+- id: 272
+  text_en: "I had to do the project backwards as people demanded results out of order."
+- id: 273
+  text_en: "I haven't had the chance to run that code yet."
+- id: 274
+  text_en: "I thought I fixed that."
+- id: 275
+  text_en: "It must be because of a leap second."
+- id: 276
+  text_en: "It was working in my head."
+- id: 277
+  text_en: "It worked yesterday."
+- id: 278
+  text_en: "It's a known bug with the server software."
+- id: 279
+  text_en: "It's an unexpected emergent behaviour of several last-minute abstractions."
+- id: 280
+  text_en: "Maybe somebody forgot to pay our hosting company."
+- id: 281
+  text_en: "My time was split in a way that meant I couldn't do either project properly."
+- id: 282
+  text_en: "That process requires human oversight that nobody was providing."
+- id: 283
+  text_en: "That code seemed so simple I didn't think it needed testing."
+- id: 284
+  text_en: "That behaviour is in the original specification."
+- id: 285
+  text_en: "That's interesting, how did you manage to make it do that?"
+- id: 286
+  text_en: "That's not a bug it's a configuration issue."
+- id: 287
+  text_en: "The WYSIWYG must have produced an invalid output."
+- id: 288
+  text_en: "The original specification contained conflicting requirements."
+- id: 289
+  text_en: "The third party API is not responding."
+- id: 290
+  text_en: "The third party documentation doesn't exist."
+- id: 291
+  text_en: "The third party documentation is wrong."
+- id: 292
+  text_en: "The unit test doesn't cover that eventuality."
+- id: 293
+  text_en: "The user must not know how to use it."
+- id: 294
+  text_en: "There must be something strange in your data."
+- id: 295
+  text_en: "There were too many developers working on that same thing."
+- id: 296
+  text_en: "This code was not supposed to go in to production yet."
+- id: 297
+  text_en: "This is a previously known bug you told me not to work on yet."
+- id: 298
+  text_en: "We didn't have enough time to peer review the final changes."
+- id: 299
+  text_en: "We outsourced that months ago."
+- id: 300
+  text_en: "We should have updated our software years ago."
+- id: 301
+  text_en: "We spent three months debugging it because we only had one month to build it."
+- id: 302
+  text_en: "Well at least we know not to try that again."
+- id: 303
+  text_en: "What did you type in wrong to get it to crash?"
+- id: 304
+  text_en: "Where were you when the program blew up?"
+- id: 305
+  text_en: "You can't use that version on your system."
+- id: 306
+  text_en: "You must be missing some of the dependencies."
+- id: 307
+  text_en: "Your browser must be caching the old content."
+- id: 308
+  text_en: "The sales department made me do it that way."
+- id: 309
+  text_en: "The sales department made me put that there."
+- id: 310
+  text_en: "The accounting department asked it to be that way."
+- id: 311
+  text_en: "The sales department asked for it to be that way."
+- id: 312
+  text_en: "That must be an accounting department error."
+- id: 313
+  text_en: "That must be a sales department error."
+- id: 314
+  text_en: "Why do they want it that way?"
+- id: 315
+  text_en: "The fail-overs must have failed."
+- id: 316
+  text_en: "You mustn't have got my email about that, check your spam."
+- id: 317
+  text_en: "There must have been a miscommunication on the requirements."
+- id: 318
+  text_en: "That's an architecture issue."
+- id: 319
+  text_en: "That's a data issue."
+- id: 320
+  text_en: "That's a user issue."
+- id: 321
+  text_en: "That's a support issue."
+- id: 322
+  text_en: "There must be an error with your data."
+- id: 323
+  text_en: "The 3rd party API must be down."
+- id: 324
+  text_en: "That is a known bug with the programming language."
+- id: 325
+  text_en: "That is a known bug with the framework."
+- id: 326
+  text_en: "That feature is part of phase two."
+- id: 327
+  text_en: "That feature is set to low priority."
+- id: 328
+  text_en: "That feature is a nice to have."
+- id: 329
+  text_en: "That is a problem with our host."
+- id: 330
+  text_en: "That is an issue with a legacy system."
+- id: 331
+  text_en: "That was like that before I started here."
+- id: 332
+  text_en: "That is a training issue."
+- id: 333
+  text_en: "There isn't the budget to address that at the moment."
+- id: 334
+  text_en: "I've not been able to recreate the issue."
+- id: 335
+  text_en: "That's been fixed, but the code still has to be released."
+- id: 336
+  text_en: "That's been fixed on another branch."
+- id: 337
+  text_en: "The developer who coded that doesn't work here anymore."
+- id: 338
+  text_en: "That is part of the old system."
+- id: 339
+  text_en: "I didn't write that part of the system."
+- id: 340
+  text_en: "It is unlikely to happen again."
+- id: 341
+  text_en: "That is a vendor issue."
+- id: 342
+  text_en: "The documentation for that feature is wrong."
+- id: 343
+  text_en: "We weren't given enough time to write unittests."
+- id: 344
+  text_en: "It must be a Y2K issue."
+- id: 345
+  text_en: "You're doing it wrong."
+- id: 346
+  text_en: "There must be a problem with the virtual machine."
+- id: 347
+  text_en: "We have to do it that way for security reasons."
+- id: 348
+  text_en: "That's a problem with a third party application."
+- id: 349
+  text_en: "It was such a simple change I didn't think it needed testing."
+- id: 350
+  text_en: "The specification contained conflicting requirements."
+- id: 351
+  text_en: "The specification was ambiguous."
+- id: 352
+  text_en: "The file must have corrupted."
+- id: 353
+  text_en: "There is nothing in my error logs."
+- id: 354
+  text_en: "You must be looking at the wrong version."
+- id: 355
+  text_en: "Your browser must be caching the old version."
+- id: 356
+  text_en: "It must just be a coincidence."
+- id: 357
+  text_en: "Our users need more training."
+- id: 358
+  text_en: "It must be a problem with your internet connection."
+- id: 359
+  text_en: "That feature isn't due in this phase."
+- id: 360
+  text_en: "That feature is outside of the project scope."
+- id: 361
+  text_en: "That's not in my job description."
+- id: 362
+  text_en: "That's the fault of the designer."
+- id: 363
+  text_en: "That's the fault of the UX designer."
+- id: 364
+  text_en: "That's the fault of the UI designer."
+- id: 365
+  text_en: "There must have been a problem with the request."
+- id: 366
+  text_en: "The browser must have dropped some packets."
+- id: 367
+  text_en: "Someone must have left some test code in."
+- id: 368
+  text_en: "We didn't have time to send that to QA."
+- id: 369
+  text_en: "That software should have been updated ages ago."
+- id: 370
+  text_en: "The client requested an XML response, but JSON is clearly better."
+- id: 371
+  text_en: "It's most likely a forwarding proxy server that is caching the response."

--- a/internal/services/excuse/excuses.yml
+++ b/internal/services/excuse/excuses.yml
@@ -1,0 +1,456 @@
+- id: 1
+  text_en: "Actually, that's a feature."
+- id: 2
+  text_en: "Did you check for a virus on your system?"
+- id: 3
+  text_en: "Even though it doesn't work, how does it feel?"
+- id: 4
+  text_en: "Everything looks fine on my end."
+- id: 5
+  text_en: "How is that possible?"
+- id: 6
+  text_en: "I broke that deliberately to do some testing."
+- id: 7
+  text_en: "I can't make that a priority right now."
+- id: 8
+  text_en: "I can't test everything."
+- id: 9
+  text_en: "I couldn't find any examples of how that can be done anywhere online."
+- id: 10
+  text_en: "I couldn't find any library that can even do that."
+- id: 11
+  text_en: "I did a quick fix last time but it broke when we rebooted."
+- id: 12
+  text_en: "I didn't anticipate that I would make any errors."
+- id: 13
+  text_en: "I didn't create that part of the program."
+- id: 14
+  text_en: "I didn't receive a ticket for it."
+- id: 15
+  text_en: "I forgot to commit the code that fixes that."
+- id: 16
+  text_en: "I have never seen that before in my life."
+- id: 17
+  text_en: "I have too many other high-priority things to do right now."
+- id: 18
+  text_en: "I haven't been able to reproduce that."
+- id: 19
+  text_en: "I haven't had a chance to run that code yet."
+- id: 20
+  text_en: "I haven't had any experience with that before."
+- id: 21
+  text_en: "I haven't touched that code in weeks."
+- id: 22
+  text_en: "I heard there was a solar flare today."
+- id: 23
+  text_en: "I must have been stress-testing our production server."
+- id: 24
+  text_en: "I must not have understood what you were asking for."
+- id: 25
+  text_en: "I thought I finished that."
+- id: 26
+  text_en: "I thought he knew the context of what I was talking about."
+- id: 27
+  text_en: "I thought you signed off on that."
+- id: 28
+  text_en: "I told you yesterday it would be done by the end of today."
+- id: 29
+  text_en: "I usually get a notification when that happens."
+- id: 30
+  text_en: "I was just fixing that."
+- id: 31
+  text_en: "I was told to stop working on that when something important came up."
+- id: 32
+  text_en: "In the interest of efficiency I only check my email for that on a Friday."
+- id: 33
+  text_en: "It can't be broken, it passes all unit tests."
+- id: 34
+  text_en: "It must be a hardware problem."
+- id: 35
+  text_en: "It must be because of a leap year."
+- id: 36
+  text_en: "It probably won't happen again."
+- id: 37
+  text_en: "It was working in my head."
+- id: 38
+  text_en: "It works for me."
+- id: 39
+  text_en: "It works, but it's not been tested."
+- id: 40
+  text_en: "It would have taken twice as long to build it properly."
+- id: 41
+  text_en: "It would take too long to rewrite the code from scratch."
+- id: 42
+  text_en: "It's a browser compatibility issue."
+- id: 43
+  text_en: "It's a character encoding issue."
+- id: 44
+  text_en: "It's a compatibility issue."
+- id: 45
+  text_en: "It's a known bug with the programming language."
+- id: 46
+  text_en: "It's a remote vendor issue."
+- id: 47
+  text_en: "It's always been like that."
+- id: 48
+  text_en: "It's an unexpected emergent behaviour of several last-minute abstractions."
+- id: 49
+  text_en: "It's just some unlucky coincidence."
+- id: 50
+  text_en: "It's never done that before."
+- id: 51
+  text_en: "It's never shown unexpected behavior like this before."
+- id: 52
+  text_en: "It's not a code problem — our users need more training."
+- id: 53
+  text_en: "I'll have to fix that at a later date."
+- id: 54
+  text_en: "I'm not familiar with it so I didn't fix it in case I made it worse."
+- id: 55
+  text_en: "I'm not getting any error codes."
+- id: 56
+  text_en: "I'm not sure as I've never had a look at how that works before."
+- id: 57
+  text_en: "I'm still working on that as we speak."
+- id: 58
+  text_en: "I'm surprised it was working at all."
+- id: 59
+  text_en: "I'm surprised it works as well as it does."
+- id: 60
+  text_en: "Management insisted we wouldn't need to waste our time writing unit tests."
+- id: 61
+  text_en: "Maybe somebody forgot to pay our hosting company."
+- id: 62
+  text_en: "My time was split in a way that meant I couldn't do either project properly."
+- id: 63
+  text_en: "No one told me so I was forced to assume which way to do that."
+- id: 64
+  text_en: "Nobody asked me how long it would actually take."
+- id: 65
+  text_en: "Nobody has ever complained about it."
+- id: 66
+  text_en: "Oh, that was just a temporary fix."
+- id: 67
+  text_en: "Oh, that was only supposed to be a placeholder."
+- id: 68
+  text_en: "Oh, you said you DIDN'T want that to happen?"
+- id: 69
+  text_en: "Our code quality is no worse than anyone else in the industry."
+- id: 70
+  text_en: "Our hardware is too slow to cope with demand."
+- id: 71
+  text_en: "Our internet connection must not be working."
+- id: 72
+  text_en: "Our redundant systems must have failed as well."
+- id: 73
+  text_en: "Please ignore that, it's for debugging."
+- id: 74
+  text_en: "Somebody must have changed my code."
+- id: 75
+  text_en: "THIS can't be the source of THAT."
+- id: 76
+  text_en: "That behaviour is in the original specification."
+- id: 77
+  text_en: "That code seemed so simple I didn't think it needed testing."
+- id: 78
+  text_en: "That error means it was successful."
+- id: 79
+  text_en: "That feature was slated for phase two."
+- id: 80
+  text_en: "That feature would be outside the scope."
+- id: 81
+  text_en: "That important email must have been marked as spam."
+- id: 82
+  text_en: "That isn't covered by my job description."
+- id: 83
+  text_en: "That process requires human oversight that nobody was providing."
+- id: 84
+  text_en: "That was literally a one in a million error."
+- id: 85
+  text_en: "That wasn't in the original specification."
+- id: 86
+  text_en: "That worked perfectly when I developed it."
+- id: 87
+  text_en: "That wouldn't be economically feasible."
+- id: 88
+  text_en: "That's already fixed, it just hasn't taken effect yet."
+- id: 89
+  text_en: "That's interesting, how did you manage to make it do that?"
+- id: 90
+  text_en: "That's not a bug it's a configuration issue."
+- id: 91
+  text_en: "That's the fault of the graphic designer."
+- id: 92
+  text_en: "The accounting department must have canceled that subscription."
+- id: 93
+  text_en: "The client must have been hacked."
+- id: 94
+  text_en: "The client wanted it changed at the last minute."
+- id: 95
+  text_en: "The code is compiling."
+- id: 96
+  text_en: "The DNS hasn't propagated yet."
+- id: 97
+  text_en: "The download must have been corrupted."
+- id: 98
+  text_en: "The existing design makes it difficult to do the right thing."
+- id: 99
+  text_en: "The marketing department made us put that there."
+- id: 100
+  text_en: "The person responsible doesn't work here anymore."
+- id: 101
+  text_en: "The problem seems to be with our legacy software."
+- id: 102
+  text_en: "The program has never collected that information."
+- id: 103
+  text_en: "The project manager said no one would want that feature."
+- id: 104
+  text_en: "The project manager told me to do it that way."
+- id: 105
+  text_en: "The request must have dropped some packets."
+- id: 106
+  text_en: "The specifications were ambiguous."
+- id: 107
+  text_en: "The third-party documentation doesn't exist."
+- id: 108
+  text_en: "The user must not know how to use it."
+- id: 109
+  text_en: "There must be something strange in your data."
+- id: 110
+  text_en: "There was too little data to bother with the extra functionality at the time."
+- id: 111
+  text_en: "There's currently a problem with our hosting company."
+- id: 112
+  text_en: "This code was not supposed to go into production yet."
+- id: 113
+  text_en: "This is a previously known bug you told me not to work on yet."
+- id: 114
+  text_en: "We didn't have enough time to peer review the final changes."
+- id: 115
+  text_en: "Well done, you found my easter egg!"
+- id: 116
+  text_en: "Well, at least it displays a very pretty error."
+- id: 117
+  text_en: "Well, at least we know not to try that again."
+- id: 118
+  text_en: "Well, that's a first."
+- id: 119
+  text_en: "What did I tell you about using parts of the system you don't understand?"
+- id: 120
+  text_en: "What did you type in wrong to get it to crash?"
+- id: 121
+  text_en: "Where were you when the program blew up?"
+- id: 122
+  text_en: "Why do you want to do it that way?"
+- id: 123
+  text_en: "You must have done something wrong."
+- id: 124
+  text_en: "You're doing it wrong."
+- id: 125
+  text_en: "You must have the wrong version."
+- id: 126
+  text_en: "You used the wrong compiling options in the build I made."
+- id: 127
+  text_en: "I got pulled into another project that needed to be done urgently."
+- id: 128
+  text_en: "Are you sure you don't have a problem with your internet connection?"
+- id: 129
+  text_en: "Are you sure you want it to work that way?"
+- id: 130
+  text_en: "Are you sure you've installed the latest patches to your browser?"
+- id: 131
+  text_en: "Are you sure you've installed the latest patches to your operating system?"
+- id: 132
+  text_en: "Are you sure?"
+- id: 133
+  text_en: "But we're a small team so what do you expect?"
+- id: 134
+  text_en: "But we're a startup so what do you expect?"
+- id: 135
+  text_en: "But we're underresourced so what do you expect?"
+- id: 136
+  text_en: "Everyone was sick."
+- id: 137
+  text_en: "Have you cleared your cache?"
+- id: 138
+  text_en: "Have you tried refreshing your browser?"
+- id: 139
+  text_en: "Have you updated your browser?"
+- id: 140
+  text_en: "Have you updated your OS?"
+- id: 141
+  text_en: "I couldn't reproduce that error."
+- id: 142
+  text_en: "I did a quick fix for that already, it must have been reverted."
+- id: 143
+  text_en: "I don't remember that in the original specification."
+- id: 144
+  text_en: "I don't see anything in my error logs."
+- id: 145
+  text_en: "I forgot my computer."
+- id: 146
+  text_en: "I found a bug in the Framework."
+- id: 147
+  text_en: "I had too many projects so I had to rush that feature."
+- id: 148
+  text_en: "I haven't pushed the fix up yet."
+- id: 149
+  text_en: "I just need one more day to work on that."
+- id: 150
+  text_en: "I never received a ticket for that."
+- id: 151
+  text_en: "I thought that was signed off?"
+- id: 152
+  text_en: "I was busy fixing more important issues."
+- id: 153
+  text_en: "I was sick."
+- id: 154
+  text_en: "I was sure that had been fixed."
+- id: 155
+  text_en: "I wasn't told how to do that so I had to guess which way the clients wanted it."
+- id: 156
+  text_en: "I'm pretty sure that works most of the time."
+- id: 157
+  text_en: "I'm pretty sure that's the way it is meant to work."
+- id: 158
+  text_en: "I'm still working on that part of the codebase."
+- id: 159
+  text_en: "I'm sure that was written by a contractor."
+- id: 160
+  text_en: "I'm sure that was written by a freelancer."
+- id: 161
+  text_en: "Is that not supposed to happen?"
+- id: 162
+  text_en: "It must be a browser cache error."
+- id: 163
+  text_en: "It must be a timezone issue."
+- id: 164
+  text_en: "It must be a unicode issue."
+- id: 165
+  text_en: "It must be a virus on your system."
+- id: 166
+  text_en: "It must be an issue with the corporate firewall."
+- id: 167
+  text_en: "It must be missing some dependencies."
+- id: 168
+  text_en: "It must be the corporate proxy."
+- id: 169
+  text_en: "It was only a small change so I didn't think it needed tests."
+- id: 170
+  text_en: "It was probably a race condition."
+- id: 171
+  text_en: "It's a browser issue."
+- id: 172
+  text_en: "It's just a warning, not an error."
+- id: 173
+  text_en: "It's most likely a forwarding proxy server that is caching the response."
+- id: 174
+  text_en: "It's not like I can't write that fix in like 5 minutes."
+- id: 175
+  text_en: "No, I didn't get any email from you about that."
+- id: 176
+  text_en: "Nothing has changed in the code."
+- id: 177
+  text_en: "Oh, that was only supposed to be a placeholder."
+- id: 178
+  text_en: "Oh, you said you DIDN'T want that to happen?"
+- id: 179
+  text_en: "Our code quality is up to industry standards."
+- id: 180
+  text_en: "PEBKAC."
+- id: 181
+  text_en: "Someone must have changed my code."
+- id: 182
+  text_en: "That code was written by the last dev."
+- id: 183
+  text_en: "That code wasn't meant to be in production."
+- id: 184
+  text_en: "That error means it was successful."
+- id: 185
+  text_en: "That feature is a nice-to-have."
+- id: 186
+  text_en: "That feature is low priority."
+- id: 187
+  text_en: "That feature is on our roadmap."
+- id: 188
+  text_en: "That feature isn't due in this phase."
+- id: 189
+  text_en: "That feature isn't due yet."
+- id: 190
+  text_en: "That output is only wrong 99% of the time."
+- id: 191
+  text_en: "That output is only wrong half the time."
+- id: 192
+  text_en: "That was like that before I started here."
+- id: 193
+  text_en: "That's a data model issue."
+- id: 194
+  text_en: "That's a problem with a third-party application."
+- id: 195
+  text_en: "That's a training issue."
+- id: 196
+  text_en: "That's a user issue."
+- id: 197
+  text_en: "That's a vendor issue."
+- id: 198
+  text_en: "That's just temporary and we're still working on it."
+- id: 199
+  text_en: "The client application must have dropped some packets."
+- id: 200
+  text_en: "The client requested an XML response, but JSON would've solved the issue."
+- id: 201
+  text_en: "The design makes it difficult to build this correctly."
+- id: 202
+  text_en: "The documentation for that feature is wrong."
+- id: 203
+  text_en: "The failovers must have failed."
+- id: 204
+  text_en: "The file must have been corrupted."
+- id: 205
+  text_en: "The fix for that is in progress."
+- id: 206
+  text_en: "The issue tracker was updated and some issues were lost."
+- id: 207
+  text_en: "The program was never meant to work that way."
+- id: 208
+  text_en: "The specification contained conflicting requirements."
+- id: 209
+  text_en: "The stakeholder was sick."
+- id: 210
+  text_en: "The tests didn't cover that edge case."
+- id: 211
+  text_en: "There must be a problem with the virtual machine."
+- id: 212
+  text_en: "There must have been a miscommunication during the requirements phase."
+- id: 213
+  text_en: "There must have been a problem with the request."
+- id: 214
+  text_en: "There's only a one in a million chance of that error occurring."
+- id: 215
+  text_en: "This is the first time anyone has mentioned it."
+- id: 216
+  text_en: "This wasn't filed in the issue tracker."
+- id: 217
+  text_en: "We broke that deliberately to test it."
+- id: 218
+  text_en: "We contracted that work out months ago."
+- id: 219
+  text_en: "We didn't have the budget to build it properly."
+- id: 220
+  text_en: "We didn't have time to QA that feature."
+- id: 221
+  text_en: "We don't have the bandwidth to address that at the moment."
+- id: 222
+  text_en: "We don't have the budget to address that at the moment."
+- id: 223
+  text_en: "We have to do it that way for security reasons."
+- id: 224
+  text_en: "We must have been stress testing the server."
+- id: 225
+  text_en: "We outsourced that part."
+- id: 226
+  text_en: "We were never asked to make it do that."
+- id: 227
+  text_en: "We've not been able to reproduce the problem."
+- id: 228
+  text_en: "We've not received any error notifications."


### PR DESCRIPTION
### Changelog
- Add `excuse` feature which returns a random developer excuse from the list of excuses curated from multiple sources
- Usage:
      <img width="545" alt="Screenshot 2024-12-24 at 5 16 05 PM" src="https://github.com/user-attachments/assets/fc65d13c-fdcc-46c8-9296-f3962e80a3c0" />

- Sources:
   - https://github.com/michelegera/devexcuses-api
   - https://github.com/thecatontheflat/excuses
   - https://github.com/afreeorange/developer-excuses 
   - https://github.com/lnfnunes/WFH-excuses
   - https://gist.github.com/fortytw2/78f5f9ef915cb43a3be4
   - https://github.com/GabrielCrackPro/developer-excuses-app
  