### PR TITLE
add word break to fix overflowing text in sudoku section

### DIFF
--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -66,6 +66,7 @@ code {
 	}
 	code p {
 		margin: 0 0 5px 0;
+		word-break: break-all;
 	}
 	code p:last-child {
 		margin: 0;


### PR DESCRIPTION
added word break to fix the overflowing text in code blocks

![image](https://github.com/user-attachments/assets/d706255b-122a-4133-89c1-61c59efa27c7)

