### PR TITLE
Feature: Add nanoid service to generate random string 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ dig fun.dict @dns.toys
 dig excuse @dns.toys
 
 dig A12.9352,77.6245/12.9698,77.7500.aerial @dns.toys
+
+dig 5.16.nanoid @dns.toys 
 ```
 
 ## Running locally

--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/knadh/dns.toys/internal/services/epoch"
 	"github.com/knadh/dns.toys/internal/services/excuse"
 	"github.com/knadh/dns.toys/internal/services/fx"
+	"github.com/knadh/dns.toys/internal/services/nanoid"
 	"github.com/knadh/dns.toys/internal/services/num2words"
 	"github.com/knadh/dns.toys/internal/services/random"
 	"github.com/knadh/dns.toys/internal/services/sudoku"
@@ -344,6 +345,14 @@ func main() {
 		}
 		h.register("excuse", e, mux)
 		help = append(help, []string{"return a developer excuse", "dig excuse @%s"})
+	}
+
+	// NanoID Generator
+	if ko.Bool("nanoid.enabled") {
+		n := nanoid.New(ko.Int("nanoid.max_results"), ko.Int("nanoid.max_length"))
+		h.register("nanoid", n, mux)
+
+		help = append(help, []string{"generate random NanoIDs", "dig 2.10.nanoid @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/docs/index.html
+++ b/docs/index.html
@@ -223,6 +223,14 @@
 		<p>Lists available services.</p>
 	</section>
 
+	<section class="box">
+    <h2>Generate NanoIDs</h2>
+    <code class="block">
+        <p>dig 5.10.nanoid @dns.toys</p>
+    </code>
+    <p>Generate N NanoIDs with specified length.</p>
+	</section>
+
 	<section>
 		<h1>Shortcut function</h1>
 		<div class="box">

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/matoous/go-nanoid/v2 v2.1.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/knadh/koanf v1.4.1 h1:Z0VGW/uo8NJmjd+L1Dc3S5frq6c62w5xQ9Yf4Mg3wFQ=
 github.com/knadh/koanf v1.4.1/go.mod h1:1cfH5223ZeZUOs8FU2UdTmaNfHpqgtjV0+NHjRO43gs=
+github.com/matoous/go-nanoid/v2 v2.1.0 h1:P64+dmq21hhWdtvZfEAofnvJULaRR1Yib0+PnU669bE=
+github.com/matoous/go-nanoid/v2 v2.1.0/go.mod h1:KlbGNQ+FhrUNIHUxZdL63t7tl4LaPkZNpUULS8H4uVM=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/miekg/dns v1.1.49 h1:qe0mQU3Z/XpFeE+AEBo2rqaS1IPBJ3anmqZ4XiZJVG8=
@@ -102,6 +104,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/services/nanoid/nanoid.go
+++ b/internal/services/nanoid/nanoid.go
@@ -1,0 +1,62 @@
+package nanoid
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	gonanoid "github.com/matoous/go-nanoid/v2"
+)
+
+type NanoID struct {
+    maxResults int
+    maxLength  int
+}
+
+func New(maxResults, maxLength int) *NanoID {
+    if maxResults < 1 {
+        maxResults = 1
+    }
+    if maxLength < 1 {
+        maxLength = 1
+    }
+    return &NanoID{
+        maxResults: maxResults,
+        maxLength:  maxLength,
+    }
+}
+
+// Query returns a random NanoID.
+func (n *NanoID) Query(q string) ([]string, error) {
+    parts := strings.Split(q, ".")
+    num := 1
+    length := 21 // default length for NanoID
+
+    if len(parts) > 1 {
+        num, _ = strconv.Atoi(parts[0])
+        length, _ = strconv.Atoi(parts[1])
+    }
+
+    if num < 1 || num > n.maxResults {
+        return nil, fmt.Errorf("provide 1-%d.nanoid", n.maxResults)
+    }
+    if length < 1 || length > n.maxLength {
+        return nil, fmt.Errorf("provide length 1-%d.nanoid", n.maxLength)
+    }
+
+    out := make([]string, 0, num)
+    for i := 0; i < num; i++ {
+        id, err := gonanoid.Generate("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", length)
+        if err != nil {
+            return nil, err
+        }
+        out = append(out, fmt.Sprintf(`%s 1 TXT "%s"`, q, id))
+    }
+
+    return out, nil
+}
+
+// Dump is not implemented in this package.
+func (n *NanoID) Dump() ([]byte, error) {
+    return nil, nil
+}


### PR DESCRIPTION
Added a nanoid service, which generates `N` random string  of `M` length. 

<img width="450" alt="image" src="https://github.com/user-attachments/assets/c04c1d5a-947e-4740-b21c-317cfa827a8d" />
