### PR TITLE
vitamin: Add vitamin info service.

### DIFF
--- a/cmd/dnstoys/main.go
+++ b/cmd/dnstoys/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knadh/dns.toys/internal/services/timezones"
 	"github.com/knadh/dns.toys/internal/services/units"
 	"github.com/knadh/dns.toys/internal/services/uuid"
+	"github.com/knadh/dns.toys/internal/services/vitamin"
 	"github.com/knadh/dns.toys/internal/services/weather"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/toml"
@@ -364,6 +365,17 @@ func main() {
 		}
 		h.register("ifsc", e, mux)
 		help = append(help, []string{"lookup (Indian) bank details by IFSC code", "dig ABNA0000001.ifsc @%s"})
+	}
+
+	// Vitamin service
+	if ko.Bool("vitamin.enabled") {
+		v, err := vitamin.New(ko.MustString("vitamin.file"))
+		if err != nil {
+			lo.Fatalf("Error initializing vitamin service: %v", err)
+		}
+		h.register("vitamin", v, mux)
+
+		help = append(help, []string{"get the common name, scientific name, and food sources for a vitamin", "dig b12.vitamin @%s"})
 	}
 
 	// Prepare the static help response for the `help` query.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -107,3 +107,9 @@ enabled = true
 # Run scripts/fetch-ifsc.sh data/ifsc to fetch the data from
 # https://github.com/razorpay/ifsc/releases/download/latest/by-bank.tar.gz
 data_path = "data/ifsc"
+
+[vitamin]
+enabled = true
+
+# Data populated using: https://medlineplus.gov/ency/article/002399.htm
+file = "data/vitamins.json"

--- a/data/vitamins.json
+++ b/data/vitamins.json
@@ -1,0 +1,177 @@
+{
+  "A": {
+    "common_name": "Vitamin A",
+    "scientific_name": "Retinol",
+    "sources": [
+      "Dark-colored fruits",
+      "Dark leafy vegetables",
+      "Egg yolks",
+      "Fortified milk and dairy products (cheese, yogurt, butter, and cream)",
+      "Liver, beef, and fish"
+    ]
+  },
+  "B1": {
+    "common_name": "Vitamin B1",
+    "scientific_name": "Thiamine",
+    "sources": [
+      "Dried milk",
+      "Egg",
+      "Enriched bread and flour",
+      "Lean meats",
+      "Legumes (dried beans)",
+      "Nuts and seeds",
+      "Organ meats",
+      "Peas",
+      "Whole grains"
+    ]
+  },
+  "B2": {
+    "common_name": "Vitamin B2",
+    "scientific_name": "Riboflavin",
+    "sources": [
+      "Dairy products",
+      "Eggs",
+      "Green leafy vegetables",
+      "Lean meats",
+      "Legumes",
+      "Milk",
+      "Nuts"
+    ]
+  },
+  "B3": {
+    "common_name": "Vitamin B3",
+    "scientific_name": "Niacin",
+    "sources": [
+      "Avocado",
+      "Eggs",
+      "Enriched breads and fortified cereals",
+      "Fish (tuna and salt-water fish)",
+      "Lean meats",
+      "Legumes",
+      "Nuts",
+      "Potato",
+      "Poultry"
+    ]
+  },
+  "B5": {
+    "common_name": "Vitamin B5",
+    "scientific_name": "Pantothenic Acid",
+    "sources": [
+      "Avocado",
+      "Eggs",
+      "Legumes and lentils",
+      "Milk",
+      "Mushroom",
+      "Organ meats",
+      "Poultry",
+      "White and sweet potatoes",
+      "Whole-grain cereals"
+    ]
+  },
+  "B6": {
+    "common_name": "Vitamin B6",
+    "scientific_name": "Pyridoxine",
+    "sources": [
+      "Avocado",
+      "Banana",
+      "Legumes (dried beans)",
+      "Meat",
+      "Nuts",
+      "Poultry",
+      "Whole grains (milling and processing removes a lot of this vitamin)"
+    ]
+  },
+  "B7": {
+    "common_name": "Vitamin B7",
+    "scientific_name": "Biotin",
+    "sources": [
+      "Chocolate",
+      "Cereal",
+      "Egg yolk",
+      "Legumes",
+      "Milk",
+      "Nuts",
+      "Organ meats (liver, kidney)",
+      "Pork",
+      "Yeast"
+    ]
+  },
+  "B9": {
+    "common_name": "Vitamin B9",
+    "scientific_name": "Folate or Folic Acid",
+    "sources": [
+      "Asparagus and broccoli",
+      "Beets",
+      "Brewer's yeast",
+      "Dried beans (cooked pinto, navy, kidney, and lima)",
+      "Fortified cereals",
+      "Lentils",
+      "Oranges and orange juice",
+      "Peanut butter",
+      "Wheat germ"
+    ]
+  },
+  "B12": {
+    "common_name": "Vitamin B12",
+    "scientific_name": "Cobalamin",
+    "sources": [
+      "Meat",
+      "Eggs",
+      "Fortified foods such as soymilk",
+      "Milk and milk products",
+      "Organ meats (liver and kidney)",
+      "Poultry",
+      "Shellfish"
+    ]
+  },
+  "C": {
+    "common_name": "Vitamin C",
+    "scientific_name": "Ascorbic Acid",
+    "sources": [
+      "Broccoli",
+      "Brussels sprouts",
+      "Cabbage",
+      "Cauliflower",
+      "Citrus fruits",
+      "Potatoes",
+      "Spinach",
+      "Strawberries",
+      "Tomatoes and tomato juice"
+    ]
+  },
+  "D": {
+    "common_name": "Vitamin D",
+    "scientific_name": "Calciferol (Cholecalciferol (D3) and Ergocalciferol (D2))",
+    "sources": [
+      "Fish (fatty fish such as salmon, mackerel, herring, and orange roughy",
+      "Fish liver oils (cod liver oil)",
+      "Fortified cereals",
+      "Fortified milk and dairy products (cheese, yogurt, butter, and cream)"
+    ]
+  },
+  "E": {
+    "common_name": "Vitamin E",
+    "scientific_name": "Tocopherol",
+    "sources": [
+      "Avocado",
+      "Dark green vegetables (spinach, broccoli, asparagus, and turnip greens)",
+      "Margarine (made from safflower, corn, and sunflower oil)",
+      "Oils (safflower, corn, and sunflower)",
+      "Papaya and mango",
+      "Seeds and nuts",
+      "Wheat germ and wheat germ oil"
+    ]
+  },
+  "K": {
+    "common_name": "Vitamin K",
+    "scientific_name": "Phylloquinone (K1), Menaquinones (K2), and Menadione (K3)",
+    "sources": [
+      "Cabbage",
+      "Cauliflower",
+      "Cereals",
+      "Dark green vegetables (broccoli, Brussels sprouts, and asparagus)",
+      "Dark leafy vegetables (spinach, kale, collards, and turnip greens)",
+      "Fish, liver, beef, and eggs"
+    ]
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,6 +126,10 @@
 					<td><span class="name">IFSC lookup</span><br><span class="desc">Get bank (India) details for IFSC code</span></td>
 					<td><code>dig ABNA0000001.ifsc @dns.toys</code></td>
 				</tr>
+				<tr>
+					<td><span class="name">Vitamin info</span><br><span class="desc">Get the common name, scientific name, and food sources for a vitamin</span></td>
+					<td><code>dig a.vitamin @dns.toys</code></td>
+				</tr>
 			</tbody>
 		</table>
 	</section>

--- a/internal/services/vitamin/vitamin.go
+++ b/internal/services/vitamin/vitamin.go
@@ -1,0 +1,54 @@
+package vitamin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type vitamin struct {
+	CommonName string `json:"common_name"`
+	ScientificName string `json:"scientific_name"`
+	Sources []string `json:"sources"`
+}
+
+type VitaminStore struct {
+	data map[string]vitamin
+}
+
+func New(filePath string) (*VitaminStore, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading the JSON file: %s: %w", filePath, err)
+	}
+
+	data := make(map[string]vitamin)
+	if err := json.Unmarshal(content, &data); err != nil {
+		return nil, fmt.Errorf("error unmarshalling the %s data: %w", filePath, err)
+	}
+
+	return &VitaminStore{data: data}, nil
+}
+
+func (v *VitaminStore) Query(query string) ([]string, error) {
+	var output []string
+
+	if vitaminData, ok := v.data[strings.ToUpper(query)]; ok {
+		output = []string{
+			fmt.Sprintf(`%s.vitamin. 1 IN TXT "Common name: %s"`, query, vitaminData.CommonName),
+			fmt.Sprintf(`%s.vitamin. 1 IN TXT "Scientific name: %s"`, query, vitaminData.ScientificName),
+			fmt.Sprintf(`%s.vitamin. 1 IN TXT "Sources: %s"`, query, strings.Join(vitaminData.Sources, ", ")),
+		}
+	} else {
+		output = []string{fmt.Sprintf(`%s.vitamin. 1 IN TXT "Vitamin %s not found"`, query, query)}
+	}
+
+	return output, nil
+}
+
+// Dump is not implemented in this package.
+func (v *VitaminStore) Dump() ([]byte, error) {
+	return nil, nil
+}
+


### PR DESCRIPTION
PR to add a vitamin service to query info regarding any of the 13 vitamins.

The result includes:
Common name, Scientific name, and food sources

Example:
```
dig b12.vitamin +short @127.0.0.1 -p 5354

"Common name: Vitamin B12"
"Scientific name: Cobalamin"
"Sources: Meat, Eggs, Fortified foods such as soymilk, Milk and milk products, Organ meats (liver and kidney), Poultry, Shellfish"
```

Fixes: #91.

Screenshots:

`dns.toys page`

<img width="1125" alt="Screenshot 2025-06-21 at 5 29 36 PM" src="https://github.com/user-attachments/assets/b8a7ef4d-64a8-4f9c-80f3-ba6291c9a85a" />
