### PR TITLE
Add Google Maps link to the ISS lat long in `iss.sky` service

### DIFF
--- a/internal/services/sky/sky.go
+++ b/internal/services/sky/sky.go
@@ -104,8 +104,9 @@ func (w *Sky) Query(q string) ([]string, error) {
 		q, d.Data.Info.SatID, d.Data.Info.SatName, d.Data.Positions[0].SatLatitude, d.Data.Positions[0].SatLongitude,
 		d.Data.Positions[0].SatAltitude, d.Data.Positions[0].Azimuth,
 		d.Data.Positions[0].Elevation, d.Data.Positions[0].RA, time.Unix(d.Data.Positions[0].Timestamp, 0).Format(time.RFC3339))
+	l := fmt.Sprintf(`%s %d TXT "https://maps.google.com/?q=%v,%v"`, q, d.Data.Info.SatID, d.Data.Positions[0].SatLatitude, d.Data.Positions[0].SatLongitude)
 
-	return []string{r}, nil
+	return []string{r, l}, nil
 }
 
 // Dump produces a gob dump of the cached data.


### PR DESCRIPTION
Adds the Google Maps link. Not able to set the zoom level. Tried different params and different links from the internet but it always zooms to the maximum.